### PR TITLE
chore: do not init and validate on tf lint

### DIFF
--- a/.github/actions/lint-terraform/action.yml
+++ b/.github/actions/lint-terraform/action.yml
@@ -23,16 +23,6 @@ inputs:
     description: 'The directory upon which to lint Terraform configurations.'
     type: 'string'
     required: true
-  walk_dirs:
-    description: 'Recursively iteratate the working directory to initialize and validate all child modules.'
-    type: 'boolean'
-    required: false
-    default: true
-  ignored_walk_dirs:
-    description: 'The newline delimited list of directories to ignore when recursively iterating child modules. This input accepts bash globbing.'
-    type: 'string'
-    required: false
-    default: ''
 
 runs:
   using: 'composite'
@@ -47,47 +37,6 @@ runs:
       working-directory: '${{ inputs.directory }}'
       run: |-
         terraform fmt -recursive -check -diff
-
-    - name: 'Initialize and validate sub directories'
-      if: '${{ inputs.walk_dirs }}'
-      shell: 'bash'
-      working-directory: '${{ inputs.directory }}'
-      env:
-        IGNORE_DIRS: '${{ inputs.ignored_walk_dirs }}'
-      run: |-
-        TERRAFORM_DIRS="$(find . -name '*.tf' -printf "%h\n" | sort -u | tr '\n' ' ')"
-
-        for DIR in ${TERRAFORM_DIRS}; do
-          IGNORE=false
-          for IGNORE_DIR in ${IGNORE_DIRS}; do
-            if [[ "${DIR}" == $IGNORE_DIR ]]; then
-              IGNORE=true
-              break
-            fi
-          done
-
-          if [[ "${IGNORE}" == "true" ]]; then
-            echo "IGNORE: ${DIR}"
-            continue
-          fi
-
-          echo "::group::${DIR}"
-
-          pushd "${DIR}" &>/dev/null
-          terraform init -backend=false -input=false
-          terraform validate
-          popd &>/dev/null
-
-          echo "::endgroup::"
-        done
-
-    - name: 'Initialize and validate'
-      if: '${{ !inputs.walk_dirs }}'
-      shell: 'bash'
-      working-directory: '${{ inputs.directory }}'
-      run: |-
-        terraform init -backend=false -input=false
-        terraform validate
 
     - name: 'abcxyz Terraform linter'
       uses: 'abcxyz/terraform-linter@main' # ratchet:exclude

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -132,10 +132,6 @@ jobs:
         ${{ vars.TERRAFORM_LINT_TERRAFORM_VERSION }}
       TERRAFORM_LINT_DIRECTORY: |-
         ${{ vars.TERRAFORM_LINT_DIRECTORY || 'terraform' }}
-      TERRAFORM_LINT_WALK_DIRS: |-
-        ${{ vars.TERRAFORM_LINT_WALK_DIRS || true }}
-      TERRAFORM_LINT_IGNORED_WALK_DIRS: |-
-        ${{ vars.TERRAFORM_LINT_IGNORED_WALK_DIRS || '' }}
       ##############
       ## YAML ######
       ##############
@@ -213,8 +209,6 @@ jobs:
         with:
           terraform_version: '${{ env.TERRAFORM_LINT_TERRAFORM_VERSION }}'
           directory: '${{ env.TERRAFORM_LINT_DIRECTORY }}'
-          walk_dirs: '${{ env.TERRAFORM_LINT_WALK_DIRS }}'
-          ignored_walk_dirs: '${{ env.TERRAFORM_LINT_IGNORED_WALK_DIRS }}'
 
       - name: '[YAML] lint yaml'
         if: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -125,10 +125,6 @@ jobs:
         ${{ vars.TERRAFORM_LINT_TERRAFORM_VERSION }}
       TERRAFORM_LINT_DIRECTORY: |-
         ${{ vars.TERRAFORM_LINT_DIRECTORY || 'terraform' }}
-      TERRAFORM_LINT_WALK_DIRS: |-
-        ${{ vars.TERRAFORM_LINT_WALK_DIRS || true }}
-      TERRAFORM_LINT_IGNORED_WALK_DIRS: |-
-        ${{ vars.TERRAFORM_LINT_IGNORED_WALK_DIRS || '' }}
       ##############
       ## YAML ######
       ##############
@@ -206,8 +202,6 @@ jobs:
         with:
           terraform_version: '${{ env.TERRAFORM_LINT_TERRAFORM_VERSION }}'
           directory: '${{ env.TERRAFORM_LINT_DIRECTORY }}'
-          walk_dirs: '${{ env.TERRAFORM_LINT_WALK_DIRS }}'
-          ignored_walk_dirs: '${{ env.TERRAFORM_LINT_IGNORED_WALK_DIRS }}'
 
       - name: '[YAML] lint yaml'
         if: |


### PR DESCRIPTION
Unfortunately, terraform init requires fetching all modules - some of which may be private and require authentication which we won't have access to in a linting context. Instead, we will only lint. See failure: https://github.com/abcxyz/infra-gcp/actions/runs/14479026060/job/40611621543?pr=1816