### PR TITLE
YAMLLINT: Disable comments-indentation

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -43,7 +43,7 @@ rules:
     ignore-shebangs: true
     min-spaces-from-content: 1
 
-  comments-indentation: {}
+  comments-indentation: 'disable'
 
   document-end:
     present: false


### PR DESCRIPTION
This is considered invalid:
```
foo: 
  bar:  true

  # Note  you can also enable buzz
  # buzz: true
```

But this is considered valid:
```
foo: 
  # Note  you can also enable buzz
  # buzz: true
  bar:  true
```

I don't think the linter should force ordering of comments for a particular indentation level.