### PR TITLE
fix: force github format for yamllint

### DIFF
--- a/.github/actions/lint-yaml/action.yml
+++ b/.github/actions/lint-yaml/action.yml
@@ -66,11 +66,11 @@ runs:
         ${{ hashFiles('.yamllint.yml', '.yamllint.yaml') == '' }}
       shell: 'bash'
       run: |-
-        yamllint -c "${{ steps.load-default-config.outputs.output-file }}" ${{ inputs.target }}
+        yamllint --format github -c "${{ steps.load-default-config.outputs.output-file }}" ${{ inputs.target }}
 
     - name: 'Lint (custom configuration)'
       if: |-
         ${{ hashFiles('.yamllint.yml', '.yamllint.yaml') != '' }}
       shell: 'bash'
       run: |-
-        yamllint ${{ inputs.target }}
+        yamllint --format github ${{ inputs.target }}


### PR DESCRIPTION
I'm not seeing the github annotations show up for yaml lint https://github.com/abcxyz/binary-integrity-multi-repo-poc/pull/8. This should force the format to be compatible with github annotations.