### PR TITLE
chore: do not set default terraform directory

### DIFF
--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -152,7 +152,7 @@ jobs:
       TERRAFORM_LINT_TERRAFORM_VERSION: |-
         ${{ vars.TERRAFORM_LINT_TERRAFORM_VERSION }}
       TERRAFORM_LINT_DIRECTORY: |-
-        ${{ vars.TERRAFORM_LINT_DIRECTORY || 'terraform' }}
+        ${{ vars.TERRAFORM_LINT_DIRECTORY || '' }}
       ##############
       ## YAML ######
       ##############

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,7 +141,7 @@ jobs:
       TERRAFORM_LINT_TERRAFORM_VERSION: |-
         ${{ vars.TERRAFORM_LINT_TERRAFORM_VERSION }}
       TERRAFORM_LINT_DIRECTORY: |-
-        ${{ vars.TERRAFORM_LINT_DIRECTORY || 'terraform' }}
+        ${{ vars.TERRAFORM_LINT_DIRECTORY || '' }}
       ##############
       ## YAML ######
       ##############


### PR DESCRIPTION
Now that we are not initializing we do not need to set a default dir. Both the terraform fmt and lint discover all terraform files.

NOTE: We might need to add a way to ignore certain directories like templates.

Should resolve: https://github.com/abcxyz/abcxyz-services/pull/190