### PR TITLE
feat: detect go.mod path

### DIFF
--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -69,7 +69,7 @@ jobs:
             git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
           }
           GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
-          echo "gomod-dirs -> ${GOMOD_DIRS}"
+          echo "gomod-dirs -> '${GOMOD_DIRS}'"
           if [[ "${GOMOD_DIRS}" != "[]" ]]; then
             echo "DOING IT"
             if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -66,12 +66,10 @@ jobs:
           }
           find_dirs_json() {
             local filepattern="${1}"
-            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || true
           }
           GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
-          echo "gomod-dirs -> '${GOMOD_DIRS}'"
           if [[ "${GOMOD_DIRS}" != "[]" ]]; then
-            echo "DOING IT"
             if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
               echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
             fi

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -76,9 +76,9 @@ jobs:
           # shard linting across each go.mod file.
           GOMOD_DIRS="$(find_dirs '(go.mod$)')"
           if [[ -n "${GOMOD_DIRS}" ]]; then
-            GOMOD_DIRS_OUTPUT_FOR_MATRIX="$(to_json "${GOMOD_DIRS}")"
-            echo "gomod-dirs -> ${GOMOD_DIRS_OUTPUT_FOR_MATRIX}"
-            echo "gomod-dirs=${GOMOD_DIRS_OUTPUT_FOR_MATRIX}" >> "${GITHUB_OUTPUT}"
+            GOMOD_DIRS_JSON="$(to_json "${GOMOD_DIRS}")"
+            echo "::notice::Found go.mod directories: ${GOMOD_DIRS_JSON}"
+            echo "gomod-dirs=${GOMOD_DIRS_JSON}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
           if match_files '.*\.(java)$'; then

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -71,6 +71,7 @@ jobs:
           GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
           echo "gomod-dirs -> ${GOMOD_DIRS}"
           if [[ "${GOMOD_DIRS}" != "[]" ]]; then
+            echo "DOING IT"
             if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
               echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
             fi

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -103,7 +103,7 @@ jobs:
             TARGETS+=("github" "ratchet")
           fi
           LINT_TARGETS="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETS[@]}")"
-          echo "lint-targets -> ${LINT_TARGETS}"
+          echo "::notice::Found lint targets: ${LINT_TARGETS}"
           echo "lint-targets=${LINT_TARGETS}" >> "${GITHUB_OUTPUT}"
 
   lint:

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -64,20 +64,22 @@ jobs:
             local filepattern="${1}"
             git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
           }
-          find_dirs_json() {
+          find_dirs() {
             local filepattern="${1}"
-            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || true
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort || true
           }
-          GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
-          if [[ "${GOMOD_DIRS}" != "[]" ]]; then
-            if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
-              echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
-            fi
-            echo "gomod-dirs=${GOMOD_DIRS}" >> "${GITHUB_OUTPUT}"
+          to_json() {
+            local filepaths="${1}"
+            echo "${filepaths}" | jq -R -s -c 'split("\n")[:-1]'
+          }
+          GOMOD_DIRS="$(find_dirs '(go.mod$)')"
+          if [[ -n "${GOMOD_DIRS}" ]]; then
+            GOMOD_DIRS_OUTPUT_FOR_MATRIX="$(to_json "${GOMOD_DIRS}")"
+            echo "gomod-dirs=${GOMOD_DIRS_OUTPUT_FOR_MATRIX}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
           if match_files '(go.mod$|/.*\.go$)'; then
-            TARGETS+=("golang" "golang-modules")
+            # GO linting handled separately.
           fi
           if match_files '.*\.(java)$'; then
             TARGETS+=("java")
@@ -120,24 +122,6 @@ jobs:
         lint-target: '${{ fromJSON(needs.init.outputs.lint-targets) }}'
     # TODO: Consider parsing from config file in the repo.
     env:
-      ##############
-      ## GOLANG ####
-      ##############
-      # The version of Go to install and use.
-      GO_LINT_GO_VERSION: |-
-        ${{ vars.GO_LINT_GO_VERSION }}
-      # Path to the go.mod file to extract a version.
-      GO_LINT_GO_VERSION_FILE: |-
-        ${{ vars.GO_LINT_GO_VERSION_FILE || format('{0}/go.mod', fromJson(needs.init.outputs.gomod-dirs || '["."]')[0]) }}
-      # The URL to a golangci file. This is only used if no file is found in the local directory.
-      GO_LINT_GOLANGCI_URL: |-
-        ${{ format('https://raw.githubusercontent.com/abcxyz/actions/{0}/.golangci.yml', github.sha) }}
-      # Directory in which Go files reside.
-      GO_LINT_DIRECTORY: |-
-        ${{ vars.GO_LINT_DIRECTORY || fromJson(needs.init.outputs.gomod-dirs || '["."]')[0] }}
-      # Version of golangci linter to use.
-      GO_LINT_GOLANGCI_LINT_VERSION: |-
-        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}
       ##############
       ## JAVA ######
       ##############
@@ -186,28 +170,6 @@ jobs:
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
         with:
           fetch-depth: 1 # shallow clone
-
-      - name: '[GOLANG] Lint Go'
-        if: |
-          matrix.lint-target == 'golang'
-        uses: './.github/actions/lint-go' # ratchet:exclude
-        with:
-          go_version: '${{ env.GO_LINT_GO_VERSION }}'
-          go_version_file: '${{ env.GO_LINT_GO_VERSION_FILE }}'
-          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
-          directory: '${{ env.GO_LINT_DIRECTORY }}'
-          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
-
-      - name: '[GOLANG] Lint Go modules'
-        if: |
-          matrix.lint-target == 'golang-modules'
-        uses: './.github/actions/lint-go-modules' # ratchet:exclude
-        with:
-          go_version: '${{ env.GO_LINT_GO_VERSION }}'
-          go_version_file: '${{ env.GO_LINT_GO_VERSION_FILE }}'
-          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
-          directory: '${{ env.GO_LINT_DIRECTORY }}'
-          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
 
       - name: '[JAVA] Lint Java'
         if: |
@@ -268,3 +230,66 @@ jobs:
         uses: './.github/actions/lint-github-actions' # ratchet:exclude
         with:
           actionlint_version: '${{ env.ACTIONS_LINT_ACTIONLINT_VERSION }}'
+
+      - name: '[PULL REQUEST] lint actions'
+        if: |
+          matrix.lint-target == 'pull-request'
+        uses: './.github/actions/pull-request-lint'
+        with:
+          pull_request_body: '${{ github.event.pull_request.body }}'
+
+  lint-go:
+    runs-on: |-
+      ${{ vars.LINT_RUNS_ON || 'ubuntu-latest' }}
+    needs:
+      - 'init'
+    if: |
+      needs.init.outputs.gomod-dirs != '[]' && github.repository == 'abcxyz/actions'
+    permissions:
+      contents: 'read'
+    strategy:
+      fail-fast: false
+      max-parallel: 100
+      matrix:
+        gomod-dir: '${{ fromJSON(needs.init.outputs.gomod-dirs) }}'
+    # TODO: Consider parsing from config file in the repo.
+    env:
+      ##############
+      ## GOLANG ####
+      ##############
+      # The version of Go to install and use.
+      GO_LINT_GO_VERSION: |-
+        ${{ vars.GO_LINT_GO_VERSION }}
+      # Path to the go.mod file to extract a version.
+      GO_LINT_GOLANGCI_URL: |-
+        ${{ format('https://raw.githubusercontent.com/abcxyz/actions/{0}/.golangci.yml', github.sha) }}
+      GO_LINT_GOLANGCI_LINT_VERSION: |-
+        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow clone
+
+      - name: '[GOLANG] Lint Go modules'
+        if: |
+          always()
+        uses: './.github/actions/lint-go-modules' # ratchet:exclude
+        with:
+          go_version: '${{ env.GO_LINT_GO_VERSION }}'
+          go_version_file: '${{ matrix.gomod-dir }}/go.mod'
+          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
+          directory: '${{ matrix.gomod-dir }}'
+          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
+
+      - name: '[GOLANG] Lint Go'
+        if: |
+          always()
+        uses: './.github/actions/lint-go' # ratchet:exclude
+        with:
+          go_version: '${{ env.GO_LINT_GO_VERSION }}'
+          go_version_file: '${{ matrix.gomod-dir }}/go.mod'
+          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
+          directory: '${{ matrix.gomod-dir }}'
+          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -72,15 +72,15 @@ jobs:
             local filepaths="${1}"
             echo "${filepaths}" | jq -R -s -c 'split("\n")[:-1]'
           }
+          # Go linting handled separtely from the rest of linting in order to
+          # shard linting across each go.mod file.
           GOMOD_DIRS="$(find_dirs '(go.mod$)')"
           if [[ -n "${GOMOD_DIRS}" ]]; then
             GOMOD_DIRS_OUTPUT_FOR_MATRIX="$(to_json "${GOMOD_DIRS}")"
+            echo "gomod-dirs -> ${GOMOD_DIRS_OUTPUT_FOR_MATRIX}"
             echo "gomod-dirs=${GOMOD_DIRS_OUTPUT_FOR_MATRIX}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
-          if match_files '(go.mod$|/.*\.go$)'; then
-            # GO linting handled separately.
-          fi
           if match_files '.*\.(java)$'; then
             TARGETS+=("java")
           fi

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -231,13 +231,6 @@ jobs:
         with:
           actionlint_version: '${{ env.ACTIONS_LINT_ACTIONLINT_VERSION }}'
 
-      - name: '[PULL REQUEST] lint actions'
-        if: |
-          matrix.lint-target == 'pull-request'
-        uses: './.github/actions/pull-request-lint'
-        with:
-          pull_request_body: '${{ github.event.pull_request.body }}'
-
   lint-go:
     runs-on: |-
       ${{ vars.LINT_RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -244,7 +244,7 @@ jobs:
     needs:
       - 'init'
     if: |
-      needs.init.outputs.gomod-dirs != '[]' && github.repository == 'abcxyz/actions'
+      needs.init.outputs.gomod-dirs != '' && needs.init.outputs.gomod-dirs != '[]' && github.repository == 'abcxyz/actions'
     permissions:
       contents: 'read'
     strategy:

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -69,6 +69,7 @@ jobs:
             git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
           }
           GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
+          echo "gomod-dirs -> ${GOMOD_DIRS}"
           if [[ "${GOMOD_DIRS}" != "[]" ]]; then
             if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
               echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -64,21 +64,20 @@ jobs:
             local filepattern="${1}"
             git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
           }
-          find_dirs() {
+          find_dirs_json() {
             local filepattern="${1}"
             git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
           }
+          GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
+          if [[ "${GOMOD_DIRS}" != "[]" ]]; then
+            if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
+              echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
+            fi
+            echo "gomod-dirs=${GOMOD_DIRS}" >> "${GITHUB_OUTPUT}"
+          fi
           declare -a TARGETS=()
           if match_files '(go.mod$|/.*\.go$)'; then
             TARGETS+=("golang" "golang-modules")
-            GOMOD_DIRS="$(find_dirs '(go.mod$)')"
-            len="$(echo "$GOMOD_DIRS" | jq length)"
-            if [[ "${len}" -gt "1" ]]; then
-              echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
-            fi
-            if [[ "${len}" -ge "1" ]]; then
-              echo "gomod-dirs=${GOMOD_DIRS}" >> "${GITHUB_OUTPUT}"
-            fi
           fi
           if match_files '.*\.(java)$'; then
             TARGETS+=("java")

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -41,6 +41,7 @@ jobs:
       github.repository == 'abcxyz/actions'
     outputs:
       lint-targets: '${{ steps.lint-targets.outputs.lint-targets }}'
+      gomod-dirs: '${{ steps.lint-targets.outputs.gomod-dirs }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -63,9 +64,21 @@ jobs:
             local filepattern="${1}"
             git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
           }
+          find_dirs() {
+            local filepattern="${1}"
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
+          }
           declare -a TARGETS=()
           if match_files '(go.mod$|/.*\.go$)'; then
             TARGETS+=("golang" "golang-modules")
+            GOMOD_DIRS="$(find_dirs '(go.mod$)')"
+            len="$(echo "$GOMOD_DIRS" | jq length)"
+            if [[ "${len}" -gt "1" ]]; then
+              echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
+            fi
+            if [[ "${len}" -ge "1" ]]; then
+              echo "gomod-dirs=${GOMOD_DIRS}" >> "${GITHUB_OUTPUT}"
+            fi
           fi
           if match_files '.*\.(java)$'; then
             TARGETS+=("java")
@@ -116,13 +129,13 @@ jobs:
         ${{ vars.GO_LINT_GO_VERSION }}
       # Path to the go.mod file to extract a version.
       GO_LINT_GO_VERSION_FILE: |-
-        ${{ vars.GO_LINT_GO_VERSION_FILE || 'go.mod' }}
+        ${{ vars.GO_LINT_GO_VERSION_FILE || format('{0}/go.mod', fromJson(needs.init.outputs.gomod-dirs || '["."]')[0]) }}
       # The URL to a golangci file. This is only used if no file is found in the local directory.
       GO_LINT_GOLANGCI_URL: |-
         ${{ format('https://raw.githubusercontent.com/abcxyz/actions/{0}/.golangci.yml', github.sha) }}
       # Directory in which Go files reside.
       GO_LINT_DIRECTORY: |-
-        ${{ vars.GO_LINT_DIRECTORY || '.' }}
+        ${{ vars.GO_LINT_DIRECTORY || fromJson(needs.init.outputs.gomod-dirs || '["."]')[0] }}
       # Version of golangci linter to use.
       GO_LINT_GOLANGCI_LINT_VERSION: |-
         ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,17 +63,17 @@ jobs:
           }
           to_json() {
             local filepaths="${1}"
-            echo "${filepaths}" | jq -R -s -c 'split("\n")[:-1]'
+            echo "${filepaths}" | jq -R -s -c 'split("\n")[:-1]' || true
           }
+          # Go linting handled separtely from the rest of linting in order to
+          # shard linting across each go.mod file.
           GOMOD_DIRS="$(find_dirs '(go.mod$)')"
           if [[ -n "${GOMOD_DIRS}" ]]; then
             GOMOD_DIRS_OUTPUT_FOR_MATRIX="$(to_json "${GOMOD_DIRS}")"
+            echo "gomod-dirs -> ${GOMOD_DIRS_OUTPUT_FOR_MATRIX}"
             echo "gomod-dirs=${GOMOD_DIRS_OUTPUT_FOR_MATRIX}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
-          if match_files '(go.mod$|/.*\.go$)'; then
-            # GO linting handled separately.
-          fi
           if match_files '.*\.(java)$'; then
             TARGETS+=("java")
           fi
@@ -113,7 +113,6 @@ jobs:
       max-parallel: 100
       matrix:
         lint-target: '${{ fromJSON(needs.init.outputs.lint-targets) }}'
-    # TODO: Consider parsing from config file in the repo.
     env:
       ##############
       ## JAVA ######
@@ -230,7 +229,7 @@ jobs:
     needs:
       - 'init'
     if: |
-      needs.init.outputs.gomod-dirs != '[]' && github.repository == 'abcxyz/actions'
+      needs.init.outputs.gomod-dirs != '[]' && github.repository != 'abcxyz/actions'
     permissions:
       contents: 'read'
     strategy:
@@ -238,7 +237,6 @@ jobs:
       max-parallel: 100
       matrix:
         gomod-dir: '${{ fromJSON(needs.init.outputs.gomod-dirs) }}'
-    # TODO: Consider parsing from config file in the repo.
     env:
       ##############
       ## GOLANG ####
@@ -261,7 +259,7 @@ jobs:
       - name: '[GOLANG] Lint Go modules'
         if: |
           always()
-        uses: './.github/actions/lint-go-modules' # ratchet:exclude
+        uses: 'abcxyz/actions/.github/actions/lint-go-modules@main' # ratchet:exclude
         with:
           go_version: '${{ env.GO_LINT_GO_VERSION }}'
           go_version_file: '${{ matrix.gomod-dir }}/go.mod'
@@ -272,7 +270,7 @@ jobs:
       - name: '[GOLANG] Lint Go'
         if: |
           always()
-        uses: './.github/actions/lint-go' # ratchet:exclude
+        uses: 'abcxyz/actions/.github/actions/lint-go@main' # ratchet:exclude
         with:
           go_version: '${{ env.GO_LINT_GO_VERSION }}'
           go_version_file: '${{ matrix.gomod-dir }}/go.mod'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,20 +57,22 @@ jobs:
             local filepattern="${1}"
             git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
           }
-          find_dirs_json() {
+          find_dirs() {
             local filepattern="${1}"
-            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || true
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort || true
           }
-          GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
-          if [[ "${GOMOD_DIRS}" != "[]" ]]; then
-            if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
-              echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
-            fi
-            echo "gomod-dirs=${GOMOD_DIRS}" >> "${GITHUB_OUTPUT}"
+          to_json() {
+            local filepaths="${1}"
+            echo "${filepaths}" | jq -R -s -c 'split("\n")[:-1]'
+          }
+          GOMOD_DIRS="$(find_dirs '(go.mod$)')"
+          if [[ -n "${GOMOD_DIRS}" ]]; then
+            GOMOD_DIRS_OUTPUT_FOR_MATRIX="$(to_json "${GOMOD_DIRS}")"
+            echo "gomod-dirs=${GOMOD_DIRS_OUTPUT_FOR_MATRIX}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
           if match_files '(go.mod$|/.*\.go$)'; then
-            TARGETS+=("golang" "golang-modules")
+            # GO linting handled separately.
           fi
           if match_files '.*\.(java)$'; then
             TARGETS+=("java")
@@ -113,24 +115,6 @@ jobs:
         lint-target: '${{ fromJSON(needs.init.outputs.lint-targets) }}'
     # TODO: Consider parsing from config file in the repo.
     env:
-      ##############
-      ## GOLANG ####
-      ##############
-      # The version of Go to install and use.
-      GO_LINT_GO_VERSION: |-
-        ${{ vars.GO_LINT_GO_VERSION }}
-      # Path to the go.mod file to extract a version.
-      GO_LINT_GO_VERSION_FILE: |-
-        ${{ vars.GO_LINT_GO_VERSION_FILE || format('{0}/go.mod', fromJson(needs.init.outputs.gomod-dirs || '["."]')[0]) }}
-      # The URL to a golangci file. This is only used if no file is found in the local directory.
-      GO_LINT_GOLANGCI_URL: |-
-        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/default.golangci.yml' }}
-      # Directory in which Go files reside.
-      GO_LINT_DIRECTORY: |-
-        ${{ vars.GO_LINT_DIRECTORY || fromJson(needs.init.outputs.gomod-dirs || '["."]')[0] }}
-      # Version of golangci linter to use.
-      GO_LINT_GOLANGCI_LINT_VERSION: |-
-        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}
       ##############
       ## JAVA ######
       ##############
@@ -179,28 +163,6 @@ jobs:
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
         with:
           fetch-depth: 1 # shallow clone
-
-      - name: '[GOLANG] Lint Go'
-        if: |
-          matrix.lint-target == 'golang'
-        uses: 'abcxyz/actions/.github/actions/lint-go@main' # ratchet:exclude
-        with:
-          go_version: '${{ env.GO_LINT_GO_VERSION }}'
-          go_version_file: '${{ env.GO_LINT_GO_VERSION_FILE }}'
-          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
-          directory: '${{ env.GO_LINT_DIRECTORY }}'
-          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
-
-      - name: '[GOLANG] Lint Go modules'
-        if: |
-          matrix.lint-target == 'golang-modules'
-        uses: 'abcxyz/actions/.github/actions/lint-go-modules@main' # ratchet:exclude
-        with:
-          go_version: '${{ env.GO_LINT_GO_VERSION }}'
-          go_version_file: '${{ env.GO_LINT_GO_VERSION_FILE }}'
-          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
-          directory: '${{ env.GO_LINT_DIRECTORY }}'
-          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
 
       - name: '[JAVA] Lint Java'
         if: |
@@ -261,3 +223,59 @@ jobs:
         uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude
         with:
           actionlint_version: '${{ env.ACTIONS_LINT_ACTIONLINT_VERSION }}'
+
+  lint-go:
+    runs-on: |-
+      ${{ vars.LINT_RUNS_ON || 'ubuntu-latest' }}
+    needs:
+      - 'init'
+    if: |
+      needs.init.outputs.gomod-dirs != '[]' && github.repository == 'abcxyz/actions'
+    permissions:
+      contents: 'read'
+    strategy:
+      fail-fast: false
+      max-parallel: 100
+      matrix:
+        gomod-dir: '${{ fromJSON(needs.init.outputs.gomod-dirs) }}'
+    # TODO: Consider parsing from config file in the repo.
+    env:
+      ##############
+      ## GOLANG ####
+      ##############
+      # The version of Go to install and use.
+      GO_LINT_GO_VERSION: |-
+        ${{ vars.GO_LINT_GO_VERSION }}
+      # Path to the go.mod file to extract a version.
+      GO_LINT_GOLANGCI_URL: |-
+        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/default.golangci.yml' }}
+      GO_LINT_GOLANGCI_LINT_VERSION: |-
+        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow clone
+
+      - name: '[GOLANG] Lint Go modules'
+        if: |
+          always()
+        uses: './.github/actions/lint-go-modules' # ratchet:exclude
+        with:
+          go_version: '${{ env.GO_LINT_GO_VERSION }}'
+          go_version_file: '${{ matrix.gomod-dir }}/go.mod'
+          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
+          directory: '${{ matrix.gomod-dir }}'
+          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
+
+      - name: '[GOLANG] Lint Go'
+        if: |
+          always()
+        uses: './.github/actions/lint-go' # ratchet:exclude
+        with:
+          go_version: '${{ env.GO_LINT_GO_VERSION }}'
+          go_version_file: '${{ matrix.gomod-dir }}/go.mod'
+          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
+          directory: '${{ matrix.gomod-dir }}'
+          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,9 +69,9 @@ jobs:
           # shard linting across each go.mod file.
           GOMOD_DIRS="$(find_dirs '(go.mod$)')"
           if [[ -n "${GOMOD_DIRS}" ]]; then
-            GOMOD_DIRS_OUTPUT_FOR_MATRIX="$(to_json "${GOMOD_DIRS}")"
-            echo "gomod-dirs -> ${GOMOD_DIRS_OUTPUT_FOR_MATRIX}"
-            echo "gomod-dirs=${GOMOD_DIRS_OUTPUT_FOR_MATRIX}" >> "${GITHUB_OUTPUT}"
+            GOMOD_DIRS_JSON="$(to_json "${GOMOD_DIRS}")"
+            echo "::notice::Found go.mod directories: ${GOMOD_DIRS_JSON}"
+            echo "gomod-dirs=${GOMOD_DIRS_JSON}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
           if match_files '.*\.(java)$'; then
@@ -96,7 +96,7 @@ jobs:
             TARGETS+=("github" "ratchet")
           fi
           LINT_TARGETS="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETS[@]}")"
-          echo "lint-targets -> ${LINT_TARGETS}"
+          echo "::notice::Found lint targets: ${LINT_TARGETS}"
           echo "lint-targets=${LINT_TARGETS}" >> "${GITHUB_OUTPUT}"
 
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
           }
           find_dirs_json() {
             local filepattern="${1}"
-            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || true
           }
           GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
           if [[ "${GOMOD_DIRS}" != "[]" ]]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -229,7 +229,7 @@ jobs:
     needs:
       - 'init'
     if: |
-      needs.init.outputs.gomod-dirs != '[]' && github.repository != 'abcxyz/actions'
+      needs.init.outputs.gomod-dirs != '' && needs.init.outputs.gomod-dirs != '[]' && github.repository != 'abcxyz/actions'
     permissions:
       contents: 'read'
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,7 @@ jobs:
       github.repository != 'abcxyz/actions'
     outputs:
       lint-targets: '${{ steps.lint-targets.outputs.lint-targets }}'
+      gomod-dirs: '${{ steps.lint-targets.outputs.gomod-dirs }}'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
@@ -56,6 +57,17 @@ jobs:
             local filepattern="${1}"
             git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
           }
+          find_dirs_json() {
+            local filepattern="${1}"
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort | jq -R -s -c 'split("\n")[:-1]' || echo '[]'
+          }
+          GOMOD_DIRS="$(find_dirs_json '(go.mod$)')"
+          if [[ "${GOMOD_DIRS}" != "[]" ]]; then
+            if [[ "$(echo "${GOMOD_DIRS}" | jq length)" -gt "1" ]]; then
+              echo "::warning::Only the first(${GOMOD_DIRS}) will be linted. Multiple go.mod are not supported."
+            fi
+            echo "gomod-dirs=${GOMOD_DIRS}" >> "${GITHUB_OUTPUT}"
+          fi
           declare -a TARGETS=()
           if match_files '(go.mod$|/.*\.go$)'; then
             TARGETS+=("golang" "golang-modules")
@@ -109,13 +121,13 @@ jobs:
         ${{ vars.GO_LINT_GO_VERSION }}
       # Path to the go.mod file to extract a version.
       GO_LINT_GO_VERSION_FILE: |-
-        ${{ vars.GO_LINT_GO_VERSION_FILE || 'go.mod' }}
+        ${{ vars.GO_LINT_GO_VERSION_FILE || format('{0}/go.mod', fromJson(needs.init.outputs.gomod-dirs || '["."]')[0]) }}
       # The URL to a golangci file. This is only used if no file is found in the local directory.
       GO_LINT_GOLANGCI_URL: |-
         ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/default.golangci.yml' }}
       # Directory in which Go files reside.
       GO_LINT_DIRECTORY: |-
-        ${{ vars.GO_LINT_DIRECTORY || '.' }}
+        ${{ vars.GO_LINT_DIRECTORY || fromJson(needs.init.outputs.gomod-dirs || '["."]')[0] }}
       # Version of golangci linter to use.
       GO_LINT_GOLANGCI_LINT_VERSION: |-
         ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}


### PR DESCRIPTION
1. Automatically detect the location of go.mod files
2. Expand go linting to run on a matrix - one job for every go.mod file
3. Run both the lint-go and lint-go-modules actions in the same job instead of separate jobs but gate with `if: always()` so both always run even if one fails.

Tested here: https://github.com/abcxyz/authz-tooling/pull/49. Execution example: https://github.com/abcxyz/authz-tooling/actions/runs/14577191250/job/40885807108?pr=49

Also confirmed it works on pkg https://github.com/abcxyz/pkg/actions/runs/14578091812/job/40888563207?pr=444