### PR TITLE
Disable SC2002 -- useless use of cat, and add .shellcheckrc file

### DIFF
--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -19,20 +19,61 @@ inputs:
     description: 'File or directory containing shell files to lint.'
     type: 'string'
     default: '.'
+  shellcheckrc_url:
+    description: 'The URL to a shellcheck config file. This is only used if no file is found in the local directory.'
+    type: 'string'
+    default: 'https://raw.githubusercontent.com/abcxyz/actions/main/.shellcheckrc'
 
 runs:
   using: 'composite'
   steps:
-    - name: 'Lint Shell'
-      env:
-        TARGET: '${{ inputs.target }}'
+    - name: 'Lint (download default configuration)'
+      id: 'load-default-config'
+      if: |-
+        ${{ hashFiles('.shellcheckrc') == '' }}
+      shell: 'bash'
+      run: |-
+        # Create a unique output file outside of the checkout.
+        SHELLCHECK_RC="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.shellcheckrc"
+
+        # Download the file, passing in authentication to get a higher rate
+        # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+        curl "${{ inputs.shellcheckrc_url }}" \
+          --silent \
+          --fail \
+          --location \
+          --header "Authorization: Token ${{ github.token }}" \
+          --output "${SHELLCHECK_RC}"
+
+        # Save the result to an output.
+        echo "::notice::Wrote configuration file to ${SHELLCHECK_RC}"
+        echo "output-file=${SHELLCHECK_RC}" >> "${GITHUB_OUTPUT}"
+
+    - name: 'Lint Shell (default configuration)'
+      if: |-
+        ${{ hashFiles('.shellcheckrc') == '' }}
       shell: 'bash'
       run: |-
         find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
-          shellcheck \
-            --check-sourced \
-            --enable=all \
-            --severity=style \
-            --format=tty \
-            --color=always \
-            {} +
+        shellcheck \
+        --check-sourced \
+        --enable=all \
+        --severity=style \
+        --format=tty \
+        --color=always \
+        --rcfile="${{ steps.load-default-config.outputs.output-file }}" \
+        {} +
+
+    - name: 'Lint Shell (custom configuration)'
+      if: |-
+        ${{ hashFiles('.shellcheckrc') != '' }}
+      shell: 'bash'
+      run: |-
+        find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
+        shellcheck \
+        --check-sourced \
+        --enable=all \
+        --severity=style \
+        --format=tty \
+        --color=always \
+        {} +

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -52,28 +52,32 @@ runs:
     - name: 'Lint Shell (default configuration)'
       if: |-
         ${{ hashFiles('.shellcheckrc') == '' }}
+      env:
+        TARGET: '${{ inputs.target }}'
       shell: 'bash'
       run: |-
         find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
-        shellcheck \
-        --check-sourced \
-        --enable=all \
-        --severity=style \
-        --format=tty \
-        --color=always \
-        --rcfile="${{ steps.load-default-config.outputs.output-file }}" \
-        {} +
+          shellcheck \
+            --check-sourced \
+            --enable=all \
+            --severity=style \
+            --format=tty \
+            --color=always \
+            --rcfile="${{ steps.load-default-config.outputs.output-file }}" \
+            {} +
 
     - name: 'Lint Shell (custom configuration)'
       if: |-
         ${{ hashFiles('.shellcheckrc') != '' }}
+      env:
+        TARGET: '${{ inputs.target }}'
       shell: 'bash'
       run: |-
         find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
-        shellcheck \
-        --check-sourced \
-        --enable=all \
-        --severity=style \
-        --format=tty \
-        --color=always \
-        {} +
+          shellcheck \
+            --check-sourced \
+            --enable=all \
+            --severity=style \
+            --format=tty \
+            --color=always \
+            {} +

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,18 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Don't complain if `cat file | cmd`. Its easier to read than `cmd < file`,
+# especially for commands with many arguments. `cmd file` also doesn't always
+# work, for example with jq, the file is last argument making it hard to see.
+disable=SC2002


### PR DESCRIPTION
Arguably `cat file | command` is easier to read, as information flows from left to right.

This is especially true from something like jq, where the format is

`jq [some possibly quite long query string] file` where the file is the last positional argument.

rc file download uses pattern from yamllint action