### PR TITLE
chore: always run both tf lint and fmt checks

### DIFF
--- a/.github/actions/lint-terraform/action.yml
+++ b/.github/actions/lint-terraform/action.yml
@@ -33,12 +33,14 @@ runs:
         terraform_version: '${{ inputs.terraform_version }}'
 
     - name: 'Check formatting'
-      shell: 'bash'
+      if: 'always()'
       working-directory: '${{ inputs.directory }}'
+      shell: 'bash'
       run: |-
         terraform fmt -recursive -check -diff
 
     - name: 'abcxyz Terraform linter'
+      if: 'always()'
       uses: 'abcxyz/terraform-linter@main' # ratchet:exclude
       with:
         paths: '${{ inputs.directory }}'


### PR DESCRIPTION
Right now we fail immediately if your terraform fmt is incorrect. We should also still run the terraform lint checks so you can see both failures without having to re-push