### PR TITLE
chore: no triggers for pr on lint-actions

### DIFF
--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -23,11 +23,6 @@ name: 'lint-actions'
 
 on:
   pull_request:
-    types:
-      - 'opened'
-      - 'synchronize'
-      - 'reopened'
-      - 'edited'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
Do not re-run lint-actions if the PR is edited.