### PR TITLE
chore: ignore unknown runner labels

### DIFF
--- a/.github/actions/lint-github-actions/action.yml
+++ b/.github/actions/lint-github-actions/action.yml
@@ -35,4 +35,8 @@ runs:
     - name: 'Actionlint'
       shell: 'bash'
       run: |
-        actionlint -color -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Filepath}}@{{$err.Line}} {{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' -ignore 'SC2016:'
+        actionlint \
+          -color \
+          -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Filepath}}@{{$err.Line}} {{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' \
+          -ignore 'SC2016:' \
+          -ignore 'label ".+" is unknown'


### PR DESCRIPTION
Custom runner labels should not cause a failure.

Tested here https://github.com/abcxyz/github-metrics-aggregator/pull/372