### PR TITLE
chore: add guardian workflows

### DIFF
--- a/.github/workflows/guardian-apply.yml
+++ b/.github/workflows/guardian-apply.yml
@@ -1,0 +1,178 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Guardian apply is used to run the Terraform apply commands for a set of
+# directories after a pull request has been merged.
+name: 'guardian_apply'
+run-name: 'guardian_apply - [REF ${{ github.ref_name }}]'
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/config/'
+
+# only one apply should run at a time
+concurrency:
+  group: '${{ github.workflow }}'
+
+env:
+  GUARDIAN_VERSION: '2.0.9'
+  GUARDIAN_TERRAFORM_VERSION: '1.10.1'
+
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 2 # required to get diff between HEAD and HEAD-1
+
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        shell: 'bash'
+        env:
+          # used to create comments on pull requests (access to only this repo)
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+        run: |-
+          DIRECTORIES=$(guardian entrypoints -dir=".github/config/" -detect-changes -source-ref=HEAD~1 -dest-ref=HEAD)
+          echo "entrypoints -> ${DIRECTORIES}"
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
+
+  apply:
+    if: |
+      needs.init.outputs.directories != '[]'
+    needs:
+      - 'init'
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      pull-requests: 'write'
+
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        working_directory: '${{ fromJSON(needs.init.outputs.directories) }}'
+
+    env:
+      DIRECTORY: '${{ matrix.working_directory }}'
+      GITHUB_JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+        with:
+          create_credentials_file: false
+          export_environment_variables: false
+          workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+          service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+          token_format: 'id_token'
+          id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          id_token_include_email: true
+
+      - name: 'Mint Token'
+        id: 'mint-token'
+        uses: 'abcxyz/github-token-minter/.github/actions/minty@main' # ratchet:exclude
+        with:
+          id_token: '${{ steps.auth.outputs.id_token }}'
+          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+          requested_permissions: |-
+            {
+              "scope": "actions-repo-guardian",
+              "repositories": ["${{ github.event.repository.name }}"],
+              "permissions": {
+                "administration": "write",
+                "contents": "write",
+                "environments": "read",
+                "secrets": "write"
+              }
+            }
+
+      - name: 'Git Config'
+        run: |-
+          git config --global url."https://x-access-token:${{ steps.mint-token.outputs.token }}@github.com".insteadOf "https://github.com"
+
+      - name: 'Has guardian config'
+        id: 'has-guardian-config'
+        shell: 'bash'
+        run: |-
+          if [[ -f "./.github/config/guardian.yml" ]]; then
+            echo "has-config=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: 'Load Guardian Config'
+        uses: 'abcxyz/actions/.github/actions/load-workflow-variables@main' # ratchet:exclude
+        if: |
+          steps.has-guardian-config.outputs.has-config == 'true'
+        with:
+          working_directory: './${{ matrix.working_directory }}'
+          filepath: './.github/config/guardian.yml'
+          fail_on_missing: 'true'
+
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
+          service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'
+
+      - name: 'Setup Terraform'
+        uses: 'abcxyz/secure-setup-terraform@main' # ratchet:exclude
+        with:
+          terraform_version: '${{ env.GUARDIAN_TERRAFORM_VERSION }}'
+          terraform_module_location: './${{ matrix.working_directory }}'
+          terraform_lockfile_location: './${{ matrix.working_directory }}'
+          protect_lockfile: false
+          terraform_wrapper: false
+
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Apply'
+        shell: 'bash'
+        env:
+          # used to create comments on pull requests (access to only this repo)
+          GUARDIAN_GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
+        run: |-
+          guardian apply -dir="${DIRECTORY}" -storage="file:/${{ runner.temp }}}" -allow-lockfile-changes

--- a/.github/workflows/guardian-plan.yml
+++ b/.github/workflows/guardian-plan.yml
@@ -1,0 +1,278 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Guardian plan is used to run the Terraform plan commands for a set of
+# directories after a pull request has been created.
+name: 'guardian_plan'
+run-name: 'guardian_plan - [PR #${{ github.event.pull_request.number }}]'
+
+on:
+  pull_request_target:
+    types:
+      - 'edited'
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'ready_for_review'
+    branches:
+      - 'main'
+    paths:
+      - '.github/config/'
+  merge_group:
+
+# only one plan, per pr should run at a time
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.head_ref || github.ref }}'
+
+env:
+  GUARDIAN_VERSION: '3.0.3'
+  GUARDIAN_TERRAFORM_VERSION: '1.10.1'
+
+jobs:
+  init:
+    if: |
+      github.event_name == 'pull_request_target'
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # get everything so we can use git diff
+          ref: '${{ github.event.pull_request.head.sha }}'
+
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Remove Previous Plan Comments'
+        shell: 'bash'
+        env:
+          # used to delete old comments on pull requests (access to only this repo)
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+        run: |-
+          guardian workflows remove-guardian-comments
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        shell: 'bash'
+        env:
+          # used to create comments on pull requests (access to only this repo)
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+          BASE_REF: '${{ github.event.pull_request.base.sha }}'
+          PR_REF: '${{ github.event.pull_request.head.sha }}'
+        run: |-
+          # The BASE_REF on github is sometimes only in the main branch.
+          # We can use git merge-base to find the intersection between the
+          # main branch and PR (feature) branch.
+          FEATURE_BRANCH_BASE_REF="$(git merge-base "${PR_REF}" "${BASE_REF}")"
+          DIRECTORIES=$(guardian entrypoints -dir="terraform" -detect-changes -source-ref="${FEATURE_BRANCH_BASE_REF}" -dest-ref="${PR_REF}")
+          echo "entrypoints -> ${DIRECTORIES}"
+          echo "directories=${DIRECTORIES}" >> "${GITHUB_OUTPUT}"
+
+
+  plan:
+    if: |
+      github.event_name == 'pull_request_target' && needs.init.outputs.directories != '[]'
+    needs:
+      - 'init'
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      pull-requests: 'write'
+
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix:
+        working_directory: '${{ fromJSON(needs.init.outputs.directories) }}'
+
+    env:
+      DIRECTORY: '${{ matrix.working_directory }}'
+      GITHUB_JOB_NAME: '${{ github.job }} (${{ matrix.working_directory }})'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+        with:
+          create_credentials_file: false
+          export_environment_variables: false
+          workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+          service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+          token_format: 'id_token'
+          id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          id_token_include_email: true
+
+      - name: 'Mint Token'
+        id: 'mint-token'
+        uses: 'abcxyz/github-token-minter/.github/actions/minty@main' # ratchet:exclude
+        with:
+          id_token: '${{ steps.auth.outputs.id_token }}'
+          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+          requested_permissions: |-
+            {
+              "scope": "actions-repo-guardian",
+              "repositories": ["${{ github.event.repository.name }}"],
+              "permissions": {
+                "administration": "write",
+                "contents": "write",
+                "environments": "read",
+                "secrets": "write"
+              }
+            }
+
+      - name: 'Git Config'
+        run: |-
+          git config --global url."https://x-access-token:${{ steps.mint-token.outputs.token }}@github.com".insteadOf "https://github.com"
+
+      - name: 'Load Guardian Config'
+        uses: 'abcxyz/actions/.github/actions/load-workflow-variables@main' # ratchet:exclude
+        with:
+          working_directory: './${{ matrix.working_directory }}'
+          filepath: './guardian.yml'
+          fail_on_missing: 'true'
+
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ env.GUARDIAN_WIF_PROVIDER }}'
+          service_account: '${{ env.GUARDIAN_WIF_SERVICE_ACCOUNT }}'
+
+      - name: 'Setup Terraform'
+        uses: 'abcxyz/secure-setup-terraform@main' # ratchet:exclude
+        with:
+          terraform_version: '${{ env.GUARDIAN_TERRAFORM_VERSION }}'
+          terraform_module_location: './${{ matrix.working_directory }}'
+          terraform_lockfile_location: './${{ matrix.working_directory }}'
+          protect_lockfile: false
+          terraform_wrapper: false
+
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Plan'
+        shell: 'bash'
+        env:
+          # used to create comments on pull requests (access to only this repo)
+          GUARDIAN_GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
+        run: |-
+          guardian plan -dir="${DIRECTORY}" -storage="file:/${{ runner.temp }}}" -allow-lockfile-changes
+
+      - name: 'Aggregate Policy Data'
+        shell: 'bash'
+        env:
+          # used to call GitHub API's for data aggregation
+          GUARDIAN_GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
+        run: |-
+          guardian policy fetch-data --include-teams
+
+      - name: 'Setup OPA'
+        uses: 'open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5' # ratchet:open-policy-agent/setup-opa@v2
+        with:
+          version: 'latest'
+
+      # Use the policy definitions from the main/approved branch
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          ref: '${{ github.event.pull_request.base.sha }}'
+          path: 'guardian-policy/main'
+
+      - name: 'Evaluate Policy'
+        id: 'opa_eval'
+        shell: 'bash'
+        run: |-
+          DECISION=$(opa eval --input "${DIRECTORY}/tfplan.json" \
+            --format raw \
+            --data ./guardian-policy/main/policy/guardian/plan \
+            --data ./guardian_policy_context.json \
+            "data.guardian.plan")
+          echo "${DECISION}" > policy_results.json
+
+      - name: 'Check Policy'
+        if: 'github.event.pull_request.draft == true'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
+        run: |-
+          guardian policy enforce \
+            -dir="${DIRECTORY}" \
+            -results-file=policy_results.json \
+            --silent
+
+      - name: 'Enforce Policy'
+        if: 'github.event.pull_request.draft == false'
+        shell: 'bash'
+        env:
+          GUARDIAN_GITHUB_TOKEN: '${{ steps.mint-token.outputs.token }}'
+        run: |-
+          guardian policy enforce \
+            -dir="${DIRECTORY}" \
+            -results-file=policy_results.json
+
+  plan_success:
+    if: |
+      always() && github.event_name == 'pull_request_target'
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'init'
+      - 'plan'
+
+    permissions:
+      pull-requests: 'write'
+
+    steps:
+      - name: 'Setup Guardian'
+        uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+        with:
+          download_url: 'https://github.com/abcxyz/guardian/releases/download/v${{ env.GUARDIAN_VERSION }}/guardian_${{ env.GUARDIAN_VERSION }}_linux_amd64.tar.gz'
+          install_path: '${{ runner.temp }}/.guardian'
+          binary_subpath: 'guardian'
+          cache_key: '${{ runner.os }}_${{ runner.arch }}_guardian_${{ env.GUARDIAN_VERSION }}'
+          add_to_path: true
+
+      - name: 'Guardian Post Plan Status'
+        shell: 'bash'
+        env:
+          # used to create comments on pull requests (access to only this repo)
+          GUARDIAN_GITHUB_TOKEN: '${{ github.token }}'
+        run: |-
+          guardian workflows plan-status-comment \
+          -init-result="${{ needs.init.result }}" \
+          -plan-result="${{ needs.plan.result }}"


### PR DESCRIPTION
Goal: add an org-level guardian plan/apply that runs on any repo when they change files in .github/config/ directory, plans it in the PR, and then applies it on merge.

Context: https://docs.google.com/document/d/1nJ4wKycxev8d3-FaMwiP4a3YMMVmseofJIPwbwElIaA/edit?resourcekey=0-OYMYvuqjCVlcEbRpvq4O7w&tab=t.0

NOTES: 
* I suspect that this workflow will fail when set as a required org level workflow because of the `on::paths` setting. I suspect we cannot conditionally execute this workflow if we mark it required.
* I'm also not sure this will work at all since the apply workflow runs on::push... and the required workflows block PR context. I'm not sure we can make a required workflow run in any context except PR. I will have to test this.