### PR TITLE
fix: setup-binary skip go-getter install on cache hit

### DIFF
--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -88,7 +88,7 @@ runs:
     - name: 'Install hashicorp/go-getter'
       id: 'go-getter'
       if: |
-        steps.cache-guardian.outputs.cache-hit != 'true'
+        steps.cache-binary.outputs.cache-hit != 'true'
       shell: 'bash'
       env:
         GOGETTER_VERSION: '1.7.1'


### PR DESCRIPTION
Currently, setup-binary downloads `hashicorp/go-getter` on every workflow job since it refers to a non-existent step.