### PR TITLE
Fix references to multi-approvers action in docs

### DIFF
--- a/.github/actions/multi-approvers/README.md
+++ b/.github/actions/multi-approvers/README.md
@@ -75,7 +75,7 @@ jobs:
             }
 
       - name: 'Multi-approvers'
-        uses: 'abcxyz/pkg/.github/actions/multi-approvers'
+        uses: 'abcxyz/actions/.github/actions/multi-approvers'
         with:
           team: 'github-team-slug'
           token: '${{ steps.minty.outputs.token }}'
@@ -116,7 +116,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Multi-approvers'
-        uses: 'abcxyz/pkg/.github/actions/multi-approvers'
+        uses: 'abcxyz/actions/.github/actions/multi-approvers'
         with:
           team: 'github-team-slug'
           token: '${{ secrets.MULTI_APPROVERS_TOKEN }}'


### PR DESCRIPTION
The docs were referencing abcxyz/pkg instead of abcxyz/actions. `pkg` is
where the action was initially going to be submitted. But then we
decided to put it in `actions`. When the code was copied over, this
reference was not changed.
