### PR TITLE
fix: file scanning

### DIFF
--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -51,13 +51,21 @@ jobs:
           LC_ALL: 'C'
         shell: 'bash'
         run: |-
+          set -euo pipefail
           # match_files determines if the current git repository has any files
           # matching the given pattern. This has been performance tested
           # against a shallow checkout of chromium (future changes should be
           # tested in the same manner).
           match_files() {
             local filepattern="${1}"
-            git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
+            matches="$(git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}")"
+            code="$?"
+            if [[ -n "${matches}" ]]; then
+              # Ignore exit codes because we found a match.
+              # Exit code 141 and higher may occur because we exit early.
+              return 0
+            fi
+            return "${code}"
           }
           find_dirs() {
             local filepattern="${1}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,13 +49,21 @@ jobs:
           LC_ALL: 'C'
         shell: 'bash'
         run: |-
+          set -euo pipefail
           # match_files determines if the current git repository has any files
           # matching the given pattern. This has been performance tested
           # against a shallow checkout of chromium (future changes should be
           # tested in the same manner).
           match_files() {
             local filepattern="${1}"
-            git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
+            matches="$(git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}")"
+            code="$?"
+            if [[ -n "${matches}" ]]; then
+              # Ignore exit codes because we found a match.
+              # Exit code 141 and higher may occur because we exit early.
+              return 0
+            fi
+            return "${code}"
           }
           find_dirs() {
             local filepattern="${1}"


### PR DESCRIPTION
File scanning did not work for certain repos. We were seeing flaky behavior on lumberjack and hackathon-infra. This fix updates the match_files to ignore exit codes from grep if we successfully found a match. It looks like sometimes grep would exit early and `git ls-tree` would continue to pipe results into it which would result in a nonzero exit code like 141. 

Tested here: https://github.com/abcxyz/lumberjack/actions/runs/14716955789/job/41302509496?pr=506