### PR TITLE
Move most notice to debug to clean up logs

### DIFF
--- a/.github/actions/lint-go/action.yml
+++ b/.github/actions/lint-go/action.yml
@@ -66,7 +66,7 @@ runs:
           --output "${GOLANGCI_YML}"
 
         # Save the result to an output.
-        echo "::notice::Wrote configuration file to ${GOLANGCI_YML}"
+        echo "::debug::Wrote configuration file to ${GOLANGCI_YML}"
         echo "output-file=${GOLANGCI_YML}" >> "${GITHUB_OUTPUT}"
 
     - name: 'Lint (default configuration)'

--- a/.github/actions/lint-yaml/action.yml
+++ b/.github/actions/lint-yaml/action.yml
@@ -64,7 +64,7 @@ runs:
           --output "${YAMLLINT_YAML}"
 
         # Save the result to an output.
-        echo "::notice::Wrote configuration file to ${YAMLLINT_YAML}"
+        echo "::debug::Wrote configuration file to ${YAMLLINT_YAML}"
         echo "output-file=${YAMLLINT_YAML}" >> "${GITHUB_OUTPUT}"
 
     - name: 'Lint (default configuration)'

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -80,7 +80,7 @@ jobs:
           GOMOD_DIRS="$(find_dirs '(go.mod$)')"
           if [[ -n "${GOMOD_DIRS}" ]]; then
             GOMOD_DIRS_JSON="$(to_json "${GOMOD_DIRS}")"
-            echo "::notice::Found go.mod directories: ${GOMOD_DIRS_JSON}"
+            echo "::debug::Found go.mod directories: ${GOMOD_DIRS_JSON}"
             echo "gomod-dirs=${GOMOD_DIRS_JSON}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
@@ -106,7 +106,7 @@ jobs:
             TARGETS+=("github" "ratchet")
           fi
           LINT_TARGETS="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETS[@]}")"
-          echo "::notice::Found lint targets: ${LINT_TARGETS}"
+          echo "::debug::Found lint targets: ${LINT_TARGETS}"
           echo "lint-targets=${LINT_TARGETS}" >> "${GITHUB_OUTPUT}"
 
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,7 @@ jobs:
           GOMOD_DIRS="$(find_dirs '(go.mod$)')"
           if [[ -n "${GOMOD_DIRS}" ]]; then
             GOMOD_DIRS_JSON="$(to_json "${GOMOD_DIRS}")"
-            echo "::notice::Found go.mod directories: ${GOMOD_DIRS_JSON}"
+            echo "::debug::Found go.mod directories: ${GOMOD_DIRS_JSON}"
             echo "gomod-dirs=${GOMOD_DIRS_JSON}" >> "${GITHUB_OUTPUT}"
           fi
           declare -a TARGETS=()
@@ -104,7 +104,7 @@ jobs:
             TARGETS+=("github" "ratchet")
           fi
           LINT_TARGETS="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETS[@]}")"
-          echo "::notice::Found lint targets: ${LINT_TARGETS}"
+          echo "::debug::Found lint targets: ${LINT_TARGETS}"
           echo "lint-targets=${LINT_TARGETS}" >> "${GITHUB_OUTPUT}"
 
   lint:

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -55,7 +55,7 @@ jobs:
               --output "${MEMBERS_JSON}"
 
           # Save the result to an output.
-          echo "::notice::Downloaded members.json to ${MEMBERS_JSON}"
+          echo "::debug::Downloaded members.json to ${MEMBERS_JSON}"
           echo "output-file=${MEMBERS_JSON}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Download multi-approvers.js'
@@ -73,7 +73,7 @@ jobs:
             --output "${MULTI_APPROVERS_JS}"
 
           # Save the result to an output.
-          echo "::notice::Downloaded multi-approvers.js to ${MULTI_APPROVERS_JS}"
+          echo "::debug::Downloaded multi-approvers.js to ${MULTI_APPROVERS_JS}"
           echo "output-file=${MULTI_APPROVERS_JS}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Check approver requirements'


### PR DESCRIPTION
Now that we have a lot of linters, this is really noisy:

![CleanShot 2025-04-28 at 22 58 37@2x](https://github.com/user-attachments/assets/9969cfb6-18da-48ac-b9a9-9df1b51bda67)
