### PR TITLE
pull_request_description: handle shell escapes

### DIFF
--- a/.github/actions/pull-request-lint/action.yml
+++ b/.github/actions/pull-request-lint/action.yml
@@ -35,8 +35,10 @@ runs:
     - name: 'Check PR Description Not Empty'
       id: 'non-empty-pr-desc-check'
       shell: 'bash'
+      env:
+        PR_BODY: '${{ inputs.pull_request_body }}'
       run: |
-        if [[ -z "${{ inputs.pull_request_body }}" ]]; then
+        if [[ -z "${PR_BODY}" ]]; then
           echo "Error: Pull request description cannot be empty."
           exit 1
         else


### PR DESCRIPTION
This is why it's really really important to not pass inputs directly into the shell...

```text
This is a test
```

```script
even more of a test
```

`exit 0