### PR TITLE
chore: install shellcheck binary from source

### DIFF
--- a/.github/actions/lint-github-actions/action.yml
+++ b/.github/actions/lint-github-actions/action.yml
@@ -27,11 +27,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Remove root shellcheck'
-      shell: 'bash'
-      run: |
-        sudo rm -rf /usr/bin/shellcheck
-
     - name: 'Setup Shellcheck'
       uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
       with:

--- a/.github/actions/lint-github-actions/action.yml
+++ b/.github/actions/lint-github-actions/action.yml
@@ -19,10 +19,28 @@ inputs:
     description: 'The version of actionlint to install and use.'
     type: 'string'
     default: '1.7.7'
+  shellcheck_version:
+    description: 'The version of actionlint to install and use.'
+    type: 'string'
+    default: '0.10.0'
 
 runs:
   using: 'composite'
   steps:
+    - name: 'Remove root shellcheck'
+      shell: 'bash'
+      run: |
+        sudo rm -rf /usr/bin/shellcheck
+
+    - name: 'Setup Shellcheck'
+      uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+      with:
+        download_url: 'https://github.com/koalaman/shellcheck/releases/download/v${{ inputs.shellcheck_version }}/shellcheck-v${{ inputs.shellcheck_version }}.linux.x86_64.tar.xz'
+        install_path: '${{ runner.temp }}/.shellcheck'
+        binary_subpath: 'shellcheck-v${{ inputs.shellcheck_version }}/shellcheck'
+        cache_key: '${{ runner.os }}_${{ runner.arch }}_shellcheck_${{ inputs.shellcheck_version }}'
+        add_to_path: true
+
     - name: 'Setup Actionlint'
       uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
       with:

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -37,7 +37,7 @@ runs:
       with:
         download_url: 'https://github.com/koalaman/shellcheck/releases/download/v${{ inputs.shellcheck_version }}/shellcheck-v${{ inputs.shellcheck_version }}.linux.x86_64.tar.xz'
         install_path: '${{ runner.temp }}/.shellcheck'
-        binary_subpath: 'shellcheck-v${{ inputs.shellcheck_version }}'
+        binary_subpath: 'shellcheck-v${{ inputs.shellcheck_version }}/shellcheck'
         cache_key: '${{ runner.os }}_${{ runner.arch }}_shellcheck_${{ inputs.shellcheck_version }}'
         add_to_path: true
 

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -54,3 +54,9 @@ runs:
             --format=tty \
             --color=always \
             {} +
+
+    - name: 'Check install path'
+      if: 'always()'
+      shell: 'bash'
+      run: |
+        ls -al '${{ runner.temp }}/.shellcheck'

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -19,10 +19,32 @@ inputs:
     description: 'File or directory containing shell files to lint.'
     type: 'string'
     default: '.'
+  shellcheck_version:
+    description: 'The version of actionlint to install and use.'
+    type: 'string'
+    default: '0.10.0'
 
 runs:
   using: 'composite'
   steps:
+    - name: 'Cleanup shellcheck'
+      shell: 'bash'
+      run: |
+        shellcheck_path="$(which shellcheck)"
+        echo "Shellcheck: ${shellcheck_path}"
+        if [[ "${shellcheck_path}" != "${{ runner.temp }}/.shellcheck" ]]; then
+          rm -rf "${shellcheck_path}"
+        fi
+
+    - name: 'Setup Shellcheck'
+      uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+      with:
+        download_url: 'https://github.com/koalaman/shellcheck/releases/download/v${{ inputs.shellcheck_version }}/shellcheck-v${{ inputs.shellcheck_version }}.linux.x86_64.tar.xz'
+        install_path: '${{ runner.temp }}/.shellcheck'
+        binary_subpath: 'shellcheck'
+        cache_key: '${{ runner.os }}_${{ runner.arch }}_shellcheck_${{ inputs.shellcheck_version }}'
+        add_to_path: true
+
     - name: 'Lint Shell'
       env:
         TARGET: '${{ inputs.target }}'

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -41,7 +41,6 @@ runs:
         TARGET: '${{ inputs.target }}'
       shell: 'bash'
       run: |-
-        shellcheck --version
         find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
           shellcheck \
             --check-sourced \

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -54,9 +54,3 @@ runs:
             --format=tty \
             --color=always \
             {} +
-
-    - name: 'Check install path'
-      if: 'always()'
-      shell: 'bash'
-      run: |
-        ls -al '${{ runner.temp }}/.shellcheck'

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -27,14 +27,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Cleanup shellcheck'
+    - name: 'Remove root shellcheck'
       shell: 'bash'
       run: |
-        shellcheck_path="$(which shellcheck)"
-        echo "Shellcheck: ${shellcheck_path}"
-        if [[ "${shellcheck_path}" != "${{ runner.temp }}/.shellcheck" ]]; then
-          rm -rf "${shellcheck_path}"
-        fi
+        sudo rm -rf /usr/bin/shellcheck
 
     - name: 'Setup Shellcheck'
       uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -27,11 +27,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Remove root shellcheck'
-      shell: 'bash'
-      run: |
-        sudo rm -rf /usr/bin/shellcheck
-
     - name: 'Setup Shellcheck'
       uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
       with:
@@ -46,6 +41,7 @@ runs:
         TARGET: '${{ inputs.target }}'
       shell: 'bash'
       run: |-
+        shellcheck --version
         find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
           shellcheck \
             --check-sourced \

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -37,7 +37,7 @@ runs:
       with:
         download_url: 'https://github.com/koalaman/shellcheck/releases/download/v${{ inputs.shellcheck_version }}/shellcheck-v${{ inputs.shellcheck_version }}.linux.x86_64.tar.xz'
         install_path: '${{ runner.temp }}/.shellcheck'
-        binary_subpath: 'shellcheck'
+        binary_subpath: 'shellcheck-v${{ inputs.shellcheck_version }}'
         cache_key: '${{ runner.os }}_${{ runner.arch }}_shellcheck_${{ inputs.shellcheck_version }}'
         add_to_path: true
 


### PR DESCRIPTION
Install shellcheck from source for both the lint-shell and lint-github-actions actions. Enables us to add back the shellcheckrc https://github.com/abcxyz/actions/issues/60