### PR TITLE
Fix sort in want-lgtm-all workflow

### DIFF
--- a/.github/actions/want-lgtm/action.yml
+++ b/.github/actions/want-lgtm/action.yml
@@ -160,7 +160,7 @@ runs:
             .filter((w) =>
               w.pull_requests.map((p) => p.number).includes(context.issue.number)
             )
-            .sort((x) => x.id);
+            .sort((a, b) => b.run_number - a.run_number);
 
           // retrigger the latest run for our unsuccessful workflow run
           if (unsuccessfulRuns.length > 0) {


### PR DESCRIPTION
Fix broken sort in want-lgtm-all workflow

This updates the sorting logic in the `Re-run Status Checks` step of want-lgtm-all workflow to accurately identify the latest failed workflow run by its `run_number`.
The previous sorting method `(x) => x.id` could result in unreliable sorting. The new logic `.sort((a, b) => b.run_number - a.run_number)` uses `run_number` as a direct sequential identifier for a specific workflow execution, ensuring that the most recently failed run is correctly selected for rerun attempts.
Issue link: https://github.com/abcxyz/pkg/issues/428