### PR TITLE
fix: remove fs.stat on deleted files for create-pull-request action

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -302,7 +302,7 @@ runs:
                 // const isExec = !!((await fs.stat(file).mode) & fs.constants.S_IXUSR);
                 prCommitTree.push({
                   path: file,
-                  mode: "100644" # temp fix: default to file mode,
+                  mode: "100644", // temp fix: default to file mode
                   type: "blob",
                   sha: null,
                 });

--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -68,6 +68,11 @@ inputs:
     required: false
     default: '3'
 
+outputs:
+  pr_number:
+    description: 'The value that this action will output.'
+    value: '${{ steps.create-update-pull-request.outputs.number }}'
+
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -303,11 +303,9 @@ runs:
             await Promise.all(
               deletedPaths.map(async (file) => {
                 core.debug("processing deleted file: ${file}...")
-                // commented becausefs.stat will fail on a deleted file
-                // const isExec = !!((await fs.stat(file).mode) & fs.constants.S_IXUSR);
                 prCommitTree.push({
                   path: file,
-                  mode: "100644", // temp fix: default to file mode
+                  mode: FILE_MODE, // ignored by upstream API
                   type: "blob",
                   sha: null,
                 });

--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -298,10 +298,11 @@ runs:
             await Promise.all(
               deletedPaths.map(async (file) => {
                 core.debug("processing deleted file: ${file}...")
-                const isExec = !!((await fs.stat(file).mode) & fs.constants.S_IXUSR);
+                // commented becausefs.stat will fail on a deleted file
+                // const isExec = !!((await fs.stat(file).mode) & fs.constants.S_IXUSR);
                 prCommitTree.push({
                   path: file,
-                  mode: isExec ? EXEC_MODE : FILE_MODE,
+                  mode: "100644" # temp fix: default to file mode,
                   type: "blob",
                   sha: null,
                 });


### PR DESCRIPTION
This fixes a bug when trying to `fs.stat` on deleted files in the commit, because the files no longer exist.