### PR TITLE
Add allowlist feature for multi-approvers

### DIFF
--- a/.github/actions/multi-approvers/action.yml
+++ b/.github/actions/multi-approvers/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Team slug. The team's organization must be in the repository's organization. Example: feature-team"
     required: true
     type: 'string'
+  user-id-allowlist:
+    description: 'A comma-seperated list of GitHub User IDs to be allowlisted. PRs from these User IDs will not be subject to multi-approvers requirements. This should be used exclusively for bots that cannot be included in the GitHub team.'
+    required: false
+    type: 'string'
 
 runs:
   using: 'node20'

--- a/.github/actions/multi-approvers/src/main.ts
+++ b/.github/actions/multi-approvers/src/main.ts
@@ -36,10 +36,11 @@ function getEventName(rawEventName: string): EventName {
 
 function parseUserIds(raw: string): Set<number> {
   const ids = raw.split(",").map((v) => {
-    const n = parseInt(v.trim(), 10);
+    const trimmedV = v.trim();
+    const n = parseInt(trimmedV, 10);
     if (isNaN(n)) {
       throw new Error(
-        `Invalid allowlisted user ID: [${v}]. Full input (user-id-allowlist): [${raw}]`,
+        `Invalid allowlisted user ID: [${trimmedV}]. Full input (user-id-allowlist): [${raw}]`,
       );
     }
     return n;
@@ -54,10 +55,10 @@ export async function main(core: Core = ghCore, context: Context = ghContext) {
     const team = core.getInput("team", { required: true });
     const rawAllowlistedUserIds = core.getInput("user-id-allowlist");
     const eventName = getEventName(context.eventName);
-    const allowlistedUserIdsSet = parseUserIds(rawAllowlistedUserIds);
+    const userIdAllowlist = parseUserIds(rawAllowlistedUserIds);
 
     core.debug(
-      `Allowlisted User IDs loaded from input: ${Array.from(allowlistedUserIdsSet).join(", ")} (Count: ${allowlistedUserIdsSet.size})`,
+      `Allowlisted user IDs loaded from input: ${Array.from(userIdAllowlist).join(", ")} (Count: ${userIdAllowlist.size})`,
     );
 
     const multiApproversAction = new MultiApproversAction({
@@ -69,7 +70,7 @@ export async function main(core: Core = ghCore, context: Context = ghContext) {
       repoOwner: payload.repository!.owner.login,
       token: token,
       team: team,
-      allowlistedUserIdsSet: allowlistedUserIdsSet,
+      userIdAllowlist: userIdAllowlist,
       logDebug: core.debug,
       logInfo: core.info,
       logNotice: core.notice,

--- a/.github/actions/multi-approvers/src/main.ts
+++ b/.github/actions/multi-approvers/src/main.ts
@@ -34,12 +34,31 @@ function getEventName(rawEventName: string): EventName {
   return rawEventName as EventName;
 }
 
+function parseUserIds(raw: string): Set<number> {
+  const ids = raw.split(",").map((v) => {
+    const n = parseInt(v.trim(), 10);
+    if (isNaN(n)) {
+      throw new Error(
+        `Invalid allowlisted user ID: [${v}]. Full input (user-id-allowlist): [${raw}]`,
+      );
+    }
+    return n;
+  });
+  return new Set(ids);
+}
+
 export async function main(core: Core = ghCore, context: Context = ghContext) {
   try {
     const payload = context.payload;
     const token = core.getInput("token", { required: true });
     const team = core.getInput("team", { required: true });
+    const rawAllowlistedUserIds = core.getInput("user-id-allowlist");
     const eventName = getEventName(context.eventName);
+    const allowlistedUserIdsSet = parseUserIds(rawAllowlistedUserIds);
+
+    core.debug(
+      `Allowlisted User IDs loaded from input: ${Array.from(allowlistedUserIdsSet).join(", ")} (Count: ${allowlistedUserIdsSet.size})`,
+    );
 
     const multiApproversAction = new MultiApproversAction({
       eventName: eventName,
@@ -50,6 +69,7 @@ export async function main(core: Core = ghCore, context: Context = ghContext) {
       repoOwner: payload.repository!.owner.login,
       token: token,
       team: team,
+      allowlistedUserIdsSet: allowlistedUserIdsSet,
       logDebug: core.debug,
       logInfo: core.info,
       logNotice: core.notice,

--- a/.github/actions/multi-approvers/src/multi-approvers.ts
+++ b/.github/actions/multi-approvers/src/multi-approvers.ts
@@ -70,8 +70,7 @@ export class MultiApproversAction {
     this.logNotice = params.logNotice;
 
     this.octokit = getOctokit(params.token, params.octokitOptions);
-    this.userIdAllowlist =
-      params.userIdAllowlist || new Set<number>();
+    this.userIdAllowlist = params.userIdAllowlist || new Set<number>();
   }
 
   // Set in the constructor.

--- a/.github/actions/multi-approvers/src/multi-approvers.ts
+++ b/.github/actions/multi-approvers/src/multi-approvers.ts
@@ -36,7 +36,7 @@ export interface MultiApproversParams {
   repoOwner: string;
   token: string;
   team: string;
-  allowlistedUserIdsSet?: Set<number>;
+  userIdAllowlist?: Set<number>;
   octokitOptions?: OctokitOptions;
   // eslint-disable-next-line no-unused-vars
   logDebug: (_: string) => void;
@@ -55,7 +55,7 @@ export class MultiApproversAction {
   private readonly repoOwner: string;
   private readonly team: string;
   private readonly octokit: Octokit;
-  private readonly allowlistedUserIdsSet: Set<number>;
+  private readonly userIdAllowlist: Set<number>;
 
   constructor(params: MultiApproversParams) {
     this.eventName = params.eventName;
@@ -70,8 +70,8 @@ export class MultiApproversAction {
     this.logNotice = params.logNotice;
 
     this.octokit = getOctokit(params.token, params.octokitOptions);
-    this.allowlistedUserIdsSet =
-      params.allowlistedUserIdsSet || new Set<number>();
+    this.userIdAllowlist =
+      params.userIdAllowlist || new Set<number>();
   }
 
   // Set in the constructor.
@@ -88,7 +88,7 @@ export class MultiApproversAction {
 
   // Checks if the given login is in the trusted external user allowlist.
   private isAllowlisted(userId: number): boolean {
-    const isListed = this.allowlistedUserIdsSet.has(userId);
+    const isListed = this.userIdAllowlist.has(userId);
     if (isListed) {
       this.logDebug(`User ID '${userId}' is in the allowlist.`);
     }

--- a/.github/actions/multi-approvers/tests/main.test.ts
+++ b/.github/actions/multi-approvers/tests/main.test.ts
@@ -108,7 +108,6 @@ test("#main", { concurrency: true }, async (suite) => {
       assert.equal(
         failMsg,
         "Multi-approvers action failed: invalid allowlisted user ID: [abc]. Full input (user-id-allowlist): [123,abc,456]",
-        `Expected error message to specify 'abc', but got: ${failMsg}`,
       );
     },
   );
@@ -133,7 +132,6 @@ test("#main", { concurrency: true }, async (suite) => {
       assert.equal(
         failMsg,
         "Multi-approvers action failed: invalid allowlisted user ID: [a]. Full input (user-id-allowlist): [123, 9, 456, a, b]",
-        `Expected error message to specify 'a', but got: ${failMsg}`,
       );
     },
   );

--- a/.github/actions/multi-approvers/tests/main.test.ts
+++ b/.github/actions/multi-approvers/tests/main.test.ts
@@ -30,53 +30,38 @@ function newFakeCore(inputs: { [key: string]: string }): Core {
   } as unknown as Core;
 }
 
-function createFakePullRequestContext(): Context {
-  return {
-    eventName: "pull_request",
-    runId: 1,
-    payload: {
-      pull_request: {
-        number: 1,
-        head: {
-          ref: "fake-branch",
-        },
-        user: {
-          login: "test-user",
-          id: 12345,
-        },
+const BASE_PULL_REQUEST = {
+  eventName: "pull_request",
+  runId: 1,
+  payload: {
+    pull_request: {
+      number: 1,
+      head: {
+        ref: "fake-branch",
       },
-      repository: {
-        name: "fake-repository",
-        owner: {
-          login: "test-org",
-        },
+      user: {
+        login: "test-user",
+        id: 12345,
       },
     },
-  } as unknown as Context;
+    repository: {
+      name: "fake-repository",
+      owner: {
+        login: "test-org",
+      },
+    },
+  },
+} as unknown as Context;
+
+function createFakeContext(overrides: Partial<Context> = {}): Context {
+  return Object.assign({}, BASE_PULL_REQUEST, overrides) as Context;
 }
 
 test("#main", { concurrency: true }, async (suite) => {
   await suite.test("should fail on unsupported event", async (t) => {
     const core = newFakeCore({ token: "fake-token", team: "fake-team" });
     const setFailed = t.mock.method(core, "setFailed", () => {});
-    const context = {
-      eventName: "push",
-      runId: 1,
-      payload: {
-        pull_request: {
-          number: 1,
-          head: {
-            ref: "fake-branch",
-          },
-        },
-        repository: {
-          name: "fake-repository",
-          owner: {
-            login: "test-org",
-          },
-        },
-      },
-    } as unknown as Context;
+    const context = createFakeContext({ eventName: "push" });
 
     await main(core, context);
 
@@ -98,7 +83,7 @@ test("#main", { concurrency: true }, async (suite) => {
         "user-id-allowlist": invalidAllowlistInput,
       });
       const setFailed = t.mock.method(core, "setFailed", () => {});
-      const context = createFakePullRequestContext();
+      const context = createFakeContext();
 
       await main(core, context);
 
@@ -122,7 +107,7 @@ test("#main", { concurrency: true }, async (suite) => {
         "user-id-allowlist": allowlistWithSpacesInput,
       });
       const setFailed = t.mock.method(core, "setFailed", () => {});
-      const context = createFakePullRequestContext();
+      const context = createFakeContext();
 
       await main(core, context);
 

--- a/.github/actions/multi-approvers/tests/main.test.ts
+++ b/.github/actions/multi-approvers/tests/main.test.ts
@@ -30,6 +30,31 @@ function newFakeCore(inputs: { [key: string]: string }): Core {
   } as unknown as Core;
 }
 
+function createFakePullRequestContext(): Context {
+  return {
+    eventName: "pull_request",
+    runId: 1,
+    payload: {
+      pull_request: {
+        number: 1,
+        head: {
+          ref: "fake-branch",
+        },
+        user: {
+          login: "test-user",
+          id: 12345,
+        },
+      },
+      repository: {
+        name: "fake-repository",
+        owner: {
+          login: "test-org",
+        },
+      },
+    },
+  } as unknown as Context;
+}
+
 test("#main", { concurrency: true }, async (suite) => {
   await suite.test("should fail on unsupported event", async (t) => {
     const core = newFakeCore({ token: "fake-token", team: "fake-team" });
@@ -62,4 +87,30 @@ test("#main", { concurrency: true }, async (suite) => {
       "Multi-approvers action failed: unexpected event [push].",
     );
   });
+
+  await suite.test(
+    "should fail if user-id-allowlist contains invalid numeric ID",
+    async (t) => {
+      const invalidAllowlistInput = "123,abc,456";
+      const core = newFakeCore({
+        token: "fake-token",
+        team: "fake-team",
+        "user-id-allowlist": invalidAllowlistInput,
+      });
+      const setFailed = t.mock.method(core, "setFailed", () => {});
+      const context = createFakePullRequestContext();
+
+      await main(core, context);
+
+      assert.equal(setFailed.mock.calls.length, 1);
+      const failMsg = String(setFailed.mock.calls[0].arguments[0]);
+
+      assert.ok(
+        failMsg.includes(
+          "Multi-approvers action failed: invalid allowlisted user ID: [abc].",
+        ),
+        `Expected error message to specify 'abc', but got: ${failMsg}`,
+      );
+    },
+  );
 });

--- a/.github/actions/multi-approvers/tests/main.test.ts
+++ b/.github/actions/multi-approvers/tests/main.test.ts
@@ -105,11 +105,35 @@ test("#main", { concurrency: true }, async (suite) => {
       assert.equal(setFailed.mock.calls.length, 1);
       const failMsg = String(setFailed.mock.calls[0].arguments[0]);
 
-      assert.ok(
-        failMsg.includes(
-          "Multi-approvers action failed: invalid allowlisted user ID: [abc].",
-        ),
+      assert.equal(
+        failMsg,
+        "Multi-approvers action failed: invalid allowlisted user ID: [abc]. Full input (user-id-allowlist): [123,abc,456]",
         `Expected error message to specify 'abc', but got: ${failMsg}`,
+      );
+    },
+  );
+
+  await suite.test(
+    "should fail if user-id-allowlist contains invalid numeric IDs with spaces",
+    async (t) => {
+      const allowlistWithSpacesInput = "123, 9, 456, a, b";
+      const core = newFakeCore({
+        token: "fake-token",
+        team: "fake-team",
+        "user-id-allowlist": allowlistWithSpacesInput,
+      });
+      const setFailed = t.mock.method(core, "setFailed", () => {});
+      const context = createFakePullRequestContext();
+
+      await main(core, context);
+
+      assert.equal(setFailed.mock.calls.length, 1);
+      const failMsg = String(setFailed.mock.calls[0].arguments[0]);
+
+      assert.equal(
+        failMsg,
+        "Multi-approvers action failed: invalid allowlisted user ID: [a]. Full input (user-id-allowlist): [123, 9, 456, a, b]",
+        `Expected error message to specify 'a', but got: ${failMsg}`,
       );
     },
   );

--- a/.github/actions/multi-approvers/tests/multi-approvers.test.ts
+++ b/.github/actions/multi-approvers/tests/multi-approvers.test.ts
@@ -31,7 +31,7 @@ const BASE_PARAMS = {
   repoOwner: "acme-org",
   token: "fake-token",
   team: "roadrunners",
-  allowlistedUserIdsSet: new Set<number>(),
+  userIdAllowlist: new Set<number>(),
   octokitOptions: { request: fetch },
   // eslint-disable-next-line no-unused-vars
   logDebug: (_: string) => {},
@@ -124,7 +124,7 @@ test("#multi-approvers", { concurrency: true }, async (suite) => {
 
       // Override BASE_PARAMS to include the allowlisted user ID
       await assertDoesNotReject(nockScope, {
-        allowlistedUserIdsSet: new Set([prAuthorId]),
+        userIdAllowlist: new Set([prAuthorId]),
       });
     },
   );
@@ -155,7 +155,7 @@ test("#multi-approvers", { concurrency: true }, async (suite) => {
         nockScope,
         "This pull request has 0 of 2 required internal approvals.",
         {
-          allowlistedUserIdsSet: new Set([12345, 67890]),
+          userIdAllowlist: new Set([12345, 67890]),
         },
       );
     },


### PR DESCRIPTION
Add an allowlist of GitHub user IDs that won't require multi-approvers when raising a PR.

This add a new input `allowlisted-user-ids` via action, which is an allowlist of trusted GitHub user IDs. It will be read and parsed into a Set. `MultiApproversAction` will check if the user in on the allowlist. If so, it won't trigger multi-approvers requirement like internal users.

Fixes #68