### PR TITLE
Adds support for pull_request_target

### DIFF
--- a/.github/actions/multi-approvers/src/multi-approvers.ts
+++ b/.github/actions/multi-approvers/src/multi-approvers.ts
@@ -19,10 +19,17 @@ import { components } from "@octokit/openapi-types";
 
 type PullRequestReview = components["schemas"]["pull-request-review"];
 type Octokit = ReturnType<typeof getOctokit>;
-export type EventName = "pull_request" | "pull_request_review";
+export type EventName =
+  | "pull_request"
+  | "pull_request_review"
+  | "pull_request_target";
 
 export function isEventName(v: string): v is EventName {
-  return ["pull_request", "pull_request_review"].includes(v);
+  return [
+    "pull_request",
+    "pull_request_review",
+    "pull_request_target",
+  ].includes(v);
 }
 
 const MIN_APPROVED_COUNT = 2;

--- a/.github/actions/multi-approvers/tests/multi-approvers.test.ts
+++ b/.github/actions/multi-approvers/tests/multi-approvers.test.ts
@@ -247,6 +247,64 @@ test("#multi-approvers", { concurrency: true }, async (suite) => {
     },
   );
 
+  await suite.test(
+    "should succeed for PRs from external users and 2 internal approvals and using pull_request_target",
+    async () => {
+      const { repoOwner, repoName, pullNumber, team } = BASE_PARAMS;
+      const prLogin = "wile-e-coyote";
+      const approver1 = "approver-1";
+      const approver2 = "approver-2";
+
+      const nockScope = nock(GITHUB_API_BASE_URL)
+        .get(`/repos/${repoOwner}/${repoName}/pulls/${pullNumber}`)
+        .reply(200, {
+          owner: repoOwner,
+          pull_number: pullNumber,
+          repoName: repoName,
+          user: {
+            login: prLogin,
+          },
+        })
+        .get(`/orgs/${repoOwner}/teams/${team}/memberships/${prLogin}`)
+        .reply(404)
+        .get(`/repos/${repoOwner}/${repoName}/pulls/${pullNumber}/reviews`)
+        .reply(200, [
+          {
+            submitted_at: 1714636800,
+            user: {
+              login: approver1,
+            },
+            state: "APPROVED",
+          },
+          {
+            submitted_at: 1714636801,
+            user: {
+              login: approver2,
+            },
+            state: "APPROVED",
+          },
+        ])
+        .get(`/orgs/${repoOwner}/teams/${team}/memberships/${approver1}`)
+        .reply(200, {
+          org: repoOwner,
+          team_slug: team,
+          username: approver1,
+          role: "member",
+          state: "active",
+        })
+        .get(`/orgs/${repoOwner}/teams/${team}/memberships/${approver2}`)
+        .reply(200, {
+          org: repoOwner,
+          team_slug: team,
+          username: approver2,
+          role: "member",
+          state: "active",
+        });
+
+      await assertDoesNotReject(nockScope, {eventName: "pull_request_target"});
+    },
+  );
+
   await suite.test("should ignore PR review comments", async () => {
     const { repoOwner, repoName, pullNumber, team } = BASE_PARAMS;
     const prLogin = "wile-e-coyote";

--- a/.github/actions/multi-approvers/tests/multi-approvers.test.ts
+++ b/.github/actions/multi-approvers/tests/multi-approvers.test.ts
@@ -301,7 +301,9 @@ test("#multi-approvers", { concurrency: true }, async (suite) => {
           state: "active",
         });
 
-      await assertDoesNotReject(nockScope, {eventName: "pull_request_target"});
+      await assertDoesNotReject(nockScope, {
+        eventName: "pull_request_target",
+      });
     },
   );
 


### PR DESCRIPTION
This change allows the multi-approvers action to properly support
workflows that use the pull_request_target event.

See #68 for an explanation of the support for pull_request_target.

Fixes #78
