### PR TITLE
chore: bump google-java-format

### DIFF
--- a/.github/actions/lint-java/action.yml
+++ b/.github/actions/lint-java/action.yml
@@ -18,7 +18,7 @@ inputs:
   google_java_format_version:
     description: 'The version of google-java-format to use. This must be the full version with no leading "v" prefix.'
     type: 'string'
-    default: '1.25.2'
+    default: '1.27.0'
   directory:
     description: 'Directory in which Java files reside.'
     type: 'string'


### PR DESCRIPTION
Newer version has some changes that fix errors in https://github.com/porcupine/bristle/pull/13