### PR TITLE
chore: lint docker

### DIFF
--- a/.github/actions/lint-docker/action.yml
+++ b/.github/actions/lint-docker/action.yml
@@ -1,0 +1,100 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-docker'
+description: 'Lint docker against the abcxyz style guide.'
+inputs:
+  target:
+    description: 'File or directory containing shell files to lint.'
+    type: 'string'
+    default: '.'
+  hadolint_config_url:
+    description: 'The URL to a hadolint config file. This is only used if no file is found in the local directory.'
+    type: 'string'
+    default: 'https://raw.githubusercontent.com/abcxyz/actions/main/.hadolint.yml'
+  hadolint_version:
+    description: 'The version of hadolint to install and use.'
+    type: 'string'
+    default: '2.12.0'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Hadolint'
+      uses: 'abcxyz/actions/.github/actions/setup-binary@main' # ratchet:exclude
+      with:
+        download_url: 'https://github.com/hadolint/hadolint/releases/download/v${{ inputs.hadolint_version }}/hadolint-Linux-x86_64'
+        install_path: '${{ runner.temp }}/.hadolint'
+        binary_subpath: 'hadolint-Linux-x86_64'
+        cache_key: '${{ runner.os }}_${{ runner.arch }}_hadolint_${{ inputs.hadolint_version }}'
+        add_to_path: true
+        destination_subpath: 'hadolint'
+
+    - name: 'Lint (download default configuration)'
+      id: 'load-default-config'
+      if: |-
+        ${{ hashFiles('.hadolint.yaml', '.hadolint.yml') == '' }}
+      shell: 'bash'
+      env:
+        HADOLINT_CONFIG_URL: '${{ inputs.hadolint_config_url }}'
+      run: |-
+        # Create a unique output file outside of the checkout.
+        HADOLINT_CONFIG_YAML="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.hadolint.yml"
+
+        # Download the file, passing in authentication to get a higher rate
+        # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+        curl "${HADOLINT_CONFIG_URL}" \
+          --silent \
+          --fail \
+          --location \
+          --header "Authorization: Token ${{ github.token }}" \
+          --output "${HADOLINT_CONFIG_YAML}"
+
+        # Save the result to an output.
+        echo "::debug::Wrote configuration file to ${HADOLINT_CONFIG_YAML}"
+        echo "output-file=${HADOLINT_CONFIG_YAML}" >> "${GITHUB_OUTPUT}"
+
+    - name: 'Add problem matcher'
+      shell: 'bash'
+      working-directory: '${{ inputs.target }}'
+      run: |
+        cat > ./problem-matcher.json <<EOF
+        {
+          "problemMatcher": [
+            {
+              "owner": "abcxyz/actions",
+              "pattern": [
+                {
+                  "regexp": "^(.+):(\\\\d+)\\\\s(.+)\\\\s(error|warning|info):\\\\s(.+)$",
+                  "file": 1,
+                  "line": 2,
+                  "code": 3,
+                  "severity": 4,
+                  "message": 5
+                }
+              ]
+            }
+          ]
+        }
+        EOF
+        cat ./problem-matcher.json
+        echo "::add-matcher::$(pwd)/problem-matcher.json"
+
+    - name: 'Hadolint'
+      shell: 'bash'
+      working-directory: '${{ inputs.target }}'
+      env:
+        OUTPUT_FILE: '${{ steps.load-default-config.outputs.output-file }}'
+      run: |
+        git ls-files | grep -E '(dockerfile|Dockerfile)' | xargs hadolint --format=tty --no-color

--- a/.github/actions/lint-java/action.yml
+++ b/.github/actions/lint-java/action.yml
@@ -74,9 +74,8 @@ runs:
       env:
         GOOGLE_JAVA_FORMAT_VERSION: '${{ inputs.google_java_format_version }}'
       run: |-
-        shopt -s globstar
-
-        "${{ runner.tool_cache }}/google-java-format-${GOOGLE_JAVA_FORMAT_VERSION}" -i **/*.java
+        git ls-files | grep -E '\.(java)' | xargs \
+          "${{ runner.tool_cache }}/google-java-format-${GOOGLE_JAVA_FORMAT_VERSION}" -i
 
         if [ -n "$(git status -s -uall)" ]; then
           echo "::error title=Java formatting::Detected unformatted Java"

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -41,11 +41,12 @@ runs:
         TARGET: '${{ inputs.target }}'
       shell: 'bash'
       run: |-
-        find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
-          shellcheck \
+        # Find all bash scripts even if they don't have an explicit extension.
+        git ls-files | grep -E '^([^.]+|.*\.(sh|zsh|bash))$' | xargs file --mime-type \
+          | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' \
+          | xargs shellcheck \
             --check-sourced \
             --enable=all \
             --severity=style \
             --format=tty \
-            --color=always \
-            {} +
+            --color=always

--- a/.github/actions/lint-yaml/action.yml
+++ b/.github/actions/lint-yaml/action.yml
@@ -75,7 +75,7 @@ runs:
         OUTPUT_FILE: '${{ steps.load-default-config.outputs.output-file }}'
         TARGET: '${{ inputs.target }}'
       run: |-
-        yamllint --format github -c "${OUTPUT_FILE}" "${TARGET}"
+        git ls-files | grep -E '\.(yaml|yml)' | xargs yamllint --format github -c "${OUTPUT_FILE}"
 
     - name: 'Lint (custom configuration)'
       if: |-
@@ -84,4 +84,4 @@ runs:
       env:
         TARGET: '${{ inputs.target }}'
       run: |-
-        yamllint --format github "${TARGET}"
+        git ls-files | grep -E '\.(yaml|yml)' | xargs yamllint --format github

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -111,6 +111,9 @@ jobs:
           if match_files '.github/(actions|workflows)/.*\.(yaml|yml)$'; then
             TARGETS+=("github" "ratchet")
           fi
+          if match_files '.*\.(dockerfile|Dockerfile)$'; then
+            TARGETS+=("docker")
+          fi
           LINT_TARGETS="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETS[@]}")"
           echo "::debug::Found lint targets: ${LINT_TARGETS}"
           echo "lint-targets=${LINT_TARGETS}" >> "${GITHUB_OUTPUT}"
@@ -169,6 +172,15 @@ jobs:
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#naming-conventions-for-configuration-variables
       ACTIONS_LINT_ACTIONLINT_VERSION: |-
         ${{ vars.ACTIONS_LINT_ACTIONLINT_VERSION || '1.7.7' }}
+      ##############
+      ## DOCKER ####
+      ##############
+      DOCKER_LINT_DIRECTORY: |-
+        ${{ vars.DOCKER_LINT_DIRECTORY || '.' }}
+      DOCKER_LINT_HADOLINT_CONFIG_URL: |-
+        ${{ format('https://raw.githubusercontent.com/abcxyz/actions/{0}/.hadolint.yml', github.sha) }}
+      DOCKER_LINT_HADOLINT_VERSION: |-
+        ${{ vars.DOCKER_LINT_HADOLINT_VERSION || '2.12.0' }}
 
     steps:
       - name: 'Checkout'
@@ -228,6 +240,15 @@ jobs:
         uses: './.github/actions/lint-github-actions' # ratchet:exclude
         with:
           actionlint_version: '${{ env.ACTIONS_LINT_ACTIONLINT_VERSION }}'
+
+      - name: '[GITHUB] lint docker'
+        if: |
+          matrix.lint-target == 'docker'
+        uses: './.github/actions/lint-docker' # ratchet:exclude
+        with:
+          target: '${{ env.DOCKER_LINT_DIRECTORY }}'
+          hadolint_config_url: '${{ env.DOCKER_LINT_HADOLINT_CONFIG_URL }}'
+          hadolint_version: '${{ env.DOCKER_LINT_HADOLINT_VERSION }}'
 
   lint-go:
     runs-on: |-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -170,6 +170,15 @@ jobs:
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#naming-conventions-for-configuration-variables
       ACTIONS_LINT_ACTIONLINT_VERSION: |-
         ${{ vars.ACTIONS_LINT_ACTIONLINT_VERSION || '1.7.7' }}
+      ##############
+      ## DOCKER ####
+      ##############
+      DOCKER_LINT_DIRECTORY: |-
+        ${{ vars.DOCKER_LINT_DIRECTORY || '.' }}
+      DOCKER_LINT_HADOLINT_CONFIG_URL: |-
+        ${{ vars.DOCKER_LINT_HADOLINT_CONFIG_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/.hadolint.yml' }}
+      DOCKER_LINT_HADOLINT_VERSION: |-
+        ${{ vars.DOCKER_LINT_HADOLINT_VERSION || '2.12.0' }}
 
     steps:
       - name: 'Checkout'
@@ -235,6 +244,15 @@ jobs:
         uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude
         with:
           actionlint_version: '${{ env.ACTIONS_LINT_ACTIONLINT_VERSION }}'
+
+      - name: '[GITHUB] lint docker'
+        if: |
+          matrix.lint-target == 'docker'
+        uses: 'abcxyz/actions/.github/actions/lint-docker@main' # ratchet:exclude
+        with:
+          target: '${{ env.DOCKER_LINT_DIRECTORY }}'
+          hadolint_config_url: '${{ env.DOCKER_LINT_HADOLINT_CONFIG_URL }}'
+          hadolint_version: '${{ env.DOCKER_LINT_HADOLINT_VERSION }}'
 
   lint-go:
     runs-on: |-

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,0 +1,2 @@
+# TODO: update after initial trial period.
+no-fail: true


### PR DESCRIPTION
Uses hadolint to lint dockerfiles and updates all lint finding algorithms to use `git ls-files` so that .gitignores are respected.