### PR TITLE
chore: correctly handle file renames in create-pull-request

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -240,10 +240,10 @@ runs:
           git add -A
           git commit --allow-empty --message "automation: compute changed files"
 
-          CHANGED_PATHS="$(git diff HEAD~1 --name-only --diff-filter=d | jq --compact-output --raw-output --raw-input --slurp 'split("\n") | map(select(. != ""))')"
+          CHANGED_PATHS="$(git diff HEAD~1 --no-renames --name-only --diff-filter=d | jq --compact-output --raw-output --raw-input --slurp 'split("\n") | map(select(. != ""))')"
           echo "::debug::computed changed paths: ${CHANGED_PATHS}"
 
-          DELETED_PATHS="$(git diff HEAD~1 --name-only --diff-filter=D | jq --compact-output --raw-output --raw-input --slurp 'split("\n") | map(select(. != ""))')"
+          DELETED_PATHS="$(git diff HEAD~1 --no-renames --name-only --diff-filter=D | jq --compact-output --raw-output --raw-input --slurp 'split("\n") | map(select(. != ""))')"
           echo "::debug::computed deleted paths: ${DELETED_PATHS}"
         else
           # Ensure the given paths are a single line of valid JSON.


### PR DESCRIPTION
Tested in another repo: https://github.com/porcupine/platform-gcp-infrastructure/actions/runs/15592168989/job/43913706692. Moved files only show up in the CHANGED files list. They must show up both in the CHANGED AND DELETED lists in order to properly be handled.

Before making this change modifications that resulted in a `moved file` were incorrectly committed as `added file` and the old files were not removed leading to file duplication.