### PR TITLE
Update to latest golangci-lint version

### DIFF
--- a/.github/actions/lint-go/action.yml
+++ b/.github/actions/lint-go/action.yml
@@ -33,7 +33,7 @@ inputs:
   golangci_lint_version:
     description: 'Version of golangci linter to use'
     type: 'string'
-    default: 'v1.64'
+    default: 'v2.2'
 
 runs:
   using: 'composite'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -39,7 +39,7 @@ on:
       golangci_lint_version:
         description: 'Version of golangci linter to use'
         type: 'string'
-        default: 'v1.64'
+        default: 'v2.2'
 
 jobs:
   # modules checks if the go modules are all up-to-date. While rare with modern

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-run:
-  # default: '1m'
-  timeout: '5m'
+version: '2'
 
+run:
   # default: []
   build-tags:
     - 'all'
@@ -83,114 +82,111 @@ linters:
     - 'whitespace'
     - 'wrapcheck'
 
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - '$all'
+          deny:
+            - pkg: 'github.com/auth0/go-jwt-middleware'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/gin-contrib/*'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/contrib'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/gin'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/golang-jwt/jwe'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/golang-jwt/jwt'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/stretchr/testify'
+              desc: 'use the standard library for tests'
+
+    goheader:
+      values:
+        regexp:
+          INDENTATION: '[\t\f]+|[ ]{2,}'
+          YEAR_AUTHOR: '\d{4} .*'
+      template: |-
+        Copyright {{ YEAR_AUTHOR }}
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        {{ INDENTATION }}http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+
+    sloglint:
+      context: 'all'
+      static-msg: false
+      key-naming-case: 'snake'
+      args-on-sep-lines: true
+
+    usetesting:
+      os-temp-dir: true
+
+    wrapcheck:
+      ignore-sig-regexps:
+        - '\.ErrorOrNil\('
+        - '\.StartGRPC\('
+        - '\.StartHTTP\('
+        - '\.StartHTTPHandler\('
+        - 'retry\.RetryableError\('
+        - 'status\.Error\('
+
+  exclusions:
+    generated: 'lax'
+    presets:
+      - 'comments'
+      - 'common-false-positives'
+      - 'legacy'
+      - 'std-error-handling'
+    rules:
+      - linters:
+          - 'wrapcheck'
+        path: '_test.go'
+      - path: '(.+)\.go$'
+        text: '^G102:'
+      - path: '(.+)\.go$'
+        text: '^G115:'
+    paths:
+      - 'internal/pb'
+      - 'third_party'
+
 issues:
-  # default: []
-  exclude:
-    - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
-    - '^G115:' # gosec: there's no way to actually satisfy this linter
-
-  # default: []
-  exclude-rules:
-    # Exclude test files from certain linters
-    - path: '_test.go'
-      linters:
-        - 'wrapcheck'
-
-  # default: []
-  exclude-dirs:
-    - 'internal/pb'
-    - 'third_party'
-
-  # default: true
-  exclude-dirs-use-default: false
-
-  # default: 50
   max-issues-per-linter: 0
-
-  # default: 3
   max-same-issues: 0
 
-linters-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - '$all'
-        deny:
-          - pkg: 'github.com/auth0/go-jwt-middleware'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/gin-contrib/*'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/contrib'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/gin'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/golang-jwt/jwe'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/golang-jwt/jwt'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/stretchr/testify'
-            desc: 'use the standard library for tests'
-
-  gci:
-    sections:
-      - 'standard'
-      - 'default'
-      - 'prefix(github.com/abcxyz)'
-      - 'blank'
-      - 'dot'
-
-    skip-generated: true
-    custom-order: true
-
-  gofumpt:
-    # default: false
-    extra-rules: true
-
-  goheader:
-    values:
-      regexp:
-        YEAR_AUTHOR: '\d{4} .*'
-        INDENTATION: '[\t\f]+|[ ]{2,}'
-    # default: ""
-    template: |-
-      Copyright {{ YEAR_AUTHOR }}
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-      {{ INDENTATION }}http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-
-  sloglint:
-    # default: false
-    context: 'all'
-    # default: false
-    static-msg: false
-    # default: '' (snake, kebab, camel, pascal)
-    key-naming-case: 'snake'
-    # default: false
-    args-on-sep-lines: true
-
-  usetesting:
-    # default: false
-    os-temp-dir: true
-
-  wrapcheck:
-    ignoreSigRegexps:
-      - '\.ErrorOrNil\('
-      - '\.StartGRPC\('
-      - '\.StartHTTP\('
-      - '\.StartHTTPHandler\('
-      - 'retry\.RetryableError\('
-      - 'status\.Error\('
-
 severity:
-  # default: ''
-  default-severity: 'error'
+  default: 'error'
+
+formatters:
+  enable:
+    - 'gci'
+    - 'gofmt'
+    - 'gofumpt'
+    - 'goimports'
+  settings:
+    gci:
+      sections:
+        - 'standard'
+        - 'default'
+        - 'prefix(github.com/abcxyz)'
+        - 'blank'
+        - 'dot'
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: 'lax'
+    paths:
+      - 'internal/pb'
+      - 'third_party'

--- a/default.golangci.yml
+++ b/default.golangci.yml
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-run:
-  # default: '1m'
-  timeout: '5m'
+version: '2'
 
+run:
   # default: []
   build-tags:
     - 'all'
@@ -37,25 +36,17 @@ linters:
     - 'depguard'
     - 'dupword'
     - 'durationcheck'
-    - 'errcheck'
     - 'errchkjson'
     - 'errname'
     - 'errorlint'
     - 'exhaustive'
     - 'forcetypeassert'
-    - 'gci'
     - 'gocheckcompilerdirectives'
     - 'godot'
-    - 'gofmt'
-    - 'gofumpt'
     - 'goheader'
-    - 'goimports'
     - 'goprintffuncname'
     - 'gosec'
-    - 'gosimple'
-    - 'govet'
     - 'importas'
-    - 'ineffassign'
     - 'loggercheck'
     - 'makezero'
     - 'mirror'
@@ -73,102 +64,97 @@ linters:
     - 'spancheck'
     - 'sqlclosecheck'
     - 'staticcheck'
-    - 'stylecheck'
     - 'thelper'
-    - 'typecheck'
     - 'unconvert'
-    - 'unused'
     - 'usetesting'
     - 'wastedassign'
     - 'whitespace'
     - 'wrapcheck'
 
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - '$all'
+          deny:
+            - pkg: 'github.com/auth0/go-jwt-middleware'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/gin-contrib/*'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/contrib'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/gin'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/golang-jwt/jwe'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/golang-jwt/jwt'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/stretchr/testify'
+              desc: 'use the standard library for tests'
+
+    sloglint:
+      context: 'all'
+      static-msg: false
+      key-naming-case: 'snake'
+      args-on-sep-lines: true
+
+    usetesting:
+      os-temp-dir: true
+
+    wrapcheck:
+      ignore-sig-regexps:
+        - '\.ErrorOrNil\('
+        - '\.StartGRPC\('
+        - '\.StartHTTP\('
+        - '\.StartHTTPHandler\('
+        - 'retry\.RetryableError\('
+        - 'status\.Error\('
+
+  exclusions:
+    generated: 'lax'
+    presets:
+      - 'comments'
+      - 'common-false-positives'
+      - 'legacy'
+      - 'std-error-handling'
+    rules:
+      - linters:
+          - 'wrapcheck'
+        path: '_test.go'
+      - path: '(.+)\.go$'
+        text: '^G102:'
+      - path: '(.+)\.go$'
+        text: '^G115:'
+    paths:
+      - 'internal/pb'
+      - 'third_party'
+
 issues:
-  # default: []
-  exclude:
-    - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
-    - '^G115:' # gosec: there's no way to actually satisfy this linter
-
-  # default: []
-  exclude-rules:
-    # Exclude test files from certain linters
-    - path: '_test.go'
-      linters:
-        - 'wrapcheck'
-
-  # default: []
-  exclude-dirs:
-    - 'internal/pb'
-    - 'third_party'
-
-  # default: true
-  exclude-dirs-use-default: false
-
-  # default: 50
   max-issues-per-linter: 0
-
-  # default: 3
   max-same-issues: 0
 
-linters-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - '$all'
-        deny:
-          - pkg: 'github.com/auth0/go-jwt-middleware'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/gin-contrib/*'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/contrib'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/gin'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/golang-jwt/jwe'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/golang-jwt/jwt'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/stretchr/testify'
-            desc: 'use the standard library for tests'
-
-  gci:
-    sections:
-      - 'standard'
-      - 'default'
-      - 'blank'
-      - 'dot'
-
-    skip-generated: true
-    custom-order: true
-
-  gofumpt:
-    # default: false
-    extra-rules: true
-
-  sloglint:
-    # default: false
-    context: 'all'
-    # default: false
-    static-msg: false
-    # default: '' (snake, kebab, camel, pascal)
-    key-naming-case: 'snake'
-    # default: false
-    args-on-sep-lines: true
-
-  usetesting:
-    # default: false
-    os-temp-dir: true
-
-  wrapcheck:
-    ignoreSigRegexps:
-      - '\.ErrorOrNil\('
-      - '\.StartGRPC\('
-      - '\.StartHTTP\('
-      - '\.StartHTTPHandler\('
-      - 'retry\.RetryableError\('
-      - 'status\.Error\('
-
 severity:
-  # default: ''
-  default-severity: 'error'
+  default: 'error'
+
+formatters:
+  enable:
+    - 'gci'
+    - 'gofmt'
+    - 'gofumpt'
+    - 'goimports'
+  settings:
+    gci:
+      sections:
+        - 'standard'
+        - 'default'
+        - 'blank'
+        - 'dot'
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: 'lax'
+    paths:
+      - 'internal/pb'
+      - 'third_party'


### PR DESCRIPTION
v1.64 requires linter version v1, but the lint action requires version 2 or higher.