### PR TITLE
fix: remove typecheck in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,6 @@ linters:
     - 'staticcheck'
     - 'stylecheck'
     - 'thelper'
-    - 'typecheck'
     - 'unconvert'
     - 'unused'
     - 'usetesting'


### PR DESCRIPTION
typecheck is not a linter

explained in https://golangci-lint.run/docs/welcome/faq/#why-do-you-have-typecheck-errors

error in https://github.com/abcxyz/team-link/actions/runs/17106259148/job/48515828243?pr=152