### PR TITLE
fix: add more checks for multi approvers

### DIFF
--- a/.github/actions/multi-approvers/src/main.ts
+++ b/.github/actions/multi-approvers/src/main.ts
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/.github/actions/multi-approvers/src/main.ts
+++ b/.github/actions/multi-approvers/src/main.ts
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,8 +35,18 @@ function getEventName(rawEventName: string): EventName {
 }
 
 function parseUserIds(raw: string): Set<number> {
+  // return an empty set if the input string is null, empty, or just whitespace
+  if (!raw || raw.trim() === "") {
+    return new Set<number>();
+  }
+
   const ids = raw.split(",").map((v) => {
     const trimmedV = v.trim();
+    if (trimmedV === "") {
+      throw new Error(
+        `Invalid empty user ID found in the list. Full input (user-id-allowlist): [${raw}]`,
+      );
+    }
     const n = parseInt(trimmedV, 10);
     if (isNaN(n)) {
       throw new Error(

--- a/.github/actions/multi-approvers/tests/main.test.ts
+++ b/.github/actions/multi-approvers/tests/main.test.ts
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/.github/actions/multi-approvers/tests/main.test.ts
+++ b/.github/actions/multi-approvers/tests/main.test.ts
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This will handle situations when the input string is null, empty, or just whitespace. Add more tests as well.