### PR TITLE
chore: Bump golangci-lint to v2.5

### DIFF
--- a/.github/actions/lint-go-modules/action.yml
+++ b/.github/actions/lint-go-modules/action.yml
@@ -33,7 +33,7 @@ inputs:
   golangci_lint_version:
     description: 'Version of golangci linter to use'
     type: 'string'
-    default: 'v2.2'
+    default: 'v2.5'
 
 runs:
   using: 'composite'

--- a/.github/actions/lint-go/action.yml
+++ b/.github/actions/lint-go/action.yml
@@ -33,7 +33,7 @@ inputs:
   golangci_lint_version:
     description: 'Version of golangci linter to use'
     type: 'string'
-    default: 'v2.2'
+    default: 'v2.5'
 
 runs:
   using: 'composite'

--- a/.github/workflows/.lint-actions.yml
+++ b/.github/workflows/.lint-actions.yml
@@ -279,7 +279,7 @@ jobs:
       GO_LINT_GOLANGCI_URL: |-
         ${{ format('https://raw.githubusercontent.com/abcxyz/actions/{0}/.golangci.yml', github.sha) }}
       GO_LINT_GOLANGCI_LINT_VERSION: |-
-        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v2.2' }}
+        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v2.5' }}
 
     steps:
       - name: 'Checkout'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -39,7 +39,7 @@ on:
       golangci_lint_version:
         description: 'Version of golangci linter to use'
         type: 'string'
-        default: 'v2.2'
+        default: 'v2.5'
 
 jobs:
   # modules checks if the go modules are all up-to-date. While rare with modern

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -285,7 +285,7 @@ jobs:
       GO_LINT_GOLANGCI_URL: |-
         ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/default.golangci.yml' }}
       GO_LINT_GOLANGCI_LINT_VERSION: |-
-        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v2.2' }}
+        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v2.5' }}
 
     steps:
       - name: 'Checkout'


### PR DESCRIPTION
The current version does not support Go 1.25 which is blocking PRs.

---

For example: https://github.com/abcxyz/team-link/actions/runs/18139525219/job/51626715926?pr=164