### PR TITLE
Remove gemini-code-assit[bot] from required reviewers

### DIFF
--- a/.github/actions/want-lgtm/action.yml
+++ b/.github/actions/want-lgtm/action.yml
@@ -65,6 +65,8 @@ runs:
           const reviewStateByLogin = {};
           submittedReviews
             .filter((r) => r.user.login !== context.payload.pull_request.user.login)
+            // Gemini code assist cannot approve PRs, but it will leave comments
+            .filter((r) => r.user.login !== "gemini-code-assist[bot]")
             .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))
             .forEach((r) => {
               // add value if it doesnt not exist


### PR DESCRIPTION
This filters `gemini-code-assist[bot]` out of the required reviewers who need to Approve the PR, since Gemini is not able to approve PRs. 

We use both gemini-code-assist AND the `want_lgtm=all` tag in our repositories, and with gemini auto-reviewing things, it means that PR authors cannot use the `want_lgtm=all` tag without getting stuck in a state where they can never get approval from Gemini.


<img width="2560" height="1328" alt="image" src="https://github.com/user-attachments/assets/d0ae6eda-12de-495d-b5b3-a21ac276288d" />

<img width="1558" height="970" alt="image" src="https://github.com/user-attachments/assets/5056c756-8675-406f-ac02-fc096ac598ce" />

<img width="936" height="1023" alt="image" src="https://github.com/user-attachments/assets/fa105318-bd77-4a4b-a030-dfb59b0f5596" />
