### PR TITLE
Update multi-approvers.js -- sorting run ids based on descending order

### DIFF
--- a/.github/workflows/multi-approvers.js
+++ b/.github/workflows/multi-approvers.js
@@ -88,7 +88,7 @@ async function onPullRequestReview({workflowRef, repoName, repoOwner, branch, pr
     .filter((r) =>
       r.pull_requests.map((pr) => pr.number).includes(prNumber)
     )
-    .sort((v) => v.id);
+    .sort((a, b) => b.id - a.id);
 
   // If there are failed runs for this PR, re-run the workflow.
   if (failedRuns.length > 0) {


### PR DESCRIPTION
Change run ID sort order to descending to ensure the latest failed run is processed. Currently, ascending order causes the oldest run to be selected.