### PR TITLE
chore: remove call to minty and gcp auth

### DIFF
--- a/.github/workflows/gemini-readability.yml
+++ b/.github/workflows/gemini-readability.yml
@@ -25,6 +25,7 @@ concurrency:
 permissions:
   contents: 'read'
   id-token: 'write'
+  pull-requests: 'write'
 
 defaults:
   run:
@@ -39,34 +40,6 @@ jobs:
     if: |
       github.repository != 'abcxyz/actions'
     steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
-        with:
-          create_credentials_file: false
-          export_environment_variables: false
-          workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
-          service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
-          token_format: 'id_token'
-          id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
-          id_token_include_email: true
-
-      - name: 'Mint Token'
-        id: 'mint-token'
-        uses: 'abcxyz/github-token-minter/.github/actions/minty@main' # ratchet:exclude
-        with:
-          id_token: '${{ steps.auth.outputs.id_token }}'
-          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
-          requested_permissions: |-
-            {
-              "scope": "gemini-readability",
-              "repositories": ["*"],
-              "permissions": {
-                "contents": "read",
-                "pull_requests": "write"
-              }
-            }
-
       - name: 'Checkout repository'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
@@ -95,7 +68,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review'
         env:
-          GITHUB_TOKEN: '${{ steps.mint-token.outputs.token || github.token }}'
+          GITHUB_TOKEN: '${{ github.token }}'
           ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.pull_request.body || github.event.issue.body }}'
           PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'


### PR DESCRIPTION
The required permissions should be available for the workflow and we don't need to use minty to get a token.