### PR TITLE
Fix .readability.md to not require license header

### DIFF
--- a/.readability.md
+++ b/.readability.md
@@ -272,7 +272,7 @@ Order attributes in resource and module blocks for readability:
 
 ## YAML
 
--   **Quote all strings with single quotes. (Note for GitHub actions expressions double quotes are sometimes required.)**
+-   **Quote all strings with single quotes.** (Note for GitHub actions expressions double quotes are sometimes required.)
 
 ```yaml
 # Good


### PR DESCRIPTION
This was conflicting with the prompt which says don't comment on license headers.

Also clarified yaml quote rules.