### PR TITLE
fix: create-pr action using wrong sha

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -352,7 +352,7 @@ runs:
               owner: ${owner}
               repo:  ${repo}
               ref:   ${pullRequestPartialRef}
-              sha:   ${commit.sha}
+              sha:   ${parentSHA}
             `);
 
             // update the pr branch reference with the new git tree
@@ -360,7 +360,7 @@ runs:
               owner: owner,
               repo: repo,
               ref: pullRequestPartialRef,
-              sha: commit.sha,
+              sha: parentSHA,
               force: true
             });
           } catch (err) {


### PR DESCRIPTION
Follow up to #124 - two more locations using the wrong sha