### PR TITLE
Revert "fix: create-pr action using wrong sha"

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -352,7 +352,7 @@ runs:
               owner: ${owner}
               repo:  ${repo}
               ref:   ${pullRequestPartialRef}
-              sha:   ${parentSHA}
+              sha:   ${commit.sha}
             `);
 
             // update the pr branch reference with the new git tree
@@ -360,7 +360,7 @@ runs:
               owner: owner,
               repo: repo,
               ref: pullRequestPartialRef,
-              sha: parentSHA,
+              sha: commit.sha,
               force: true
             });
           } catch (err) {


### PR DESCRIPTION
Reverts abcxyz/actions#126

This was breaking this action by using the same reference and causing the create pull request actions to not have a diff.

See https://github.com/abcxyz/guardian/actions/runs/19448938686/job/55649545865