### PR TITLE
Add a workflow that will trigger action scanner to ensure behavior is as expected

### DIFF
--- a/.github/workflows/vulnerable_workflow.yml
+++ b/.github/workflows/vulnerable_workflow.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
         with:
           ref: '${{ github.event.pull_request.head.sha }}'
 


### PR DESCRIPTION
This should show up as a PWN request to the codeql scanner is it's checking out head sha in pull_request_target and executing.

In practice, this will never actually cause anything bad due to the `if false` in the script. (I also intend to revert this change in the next PR).

I want to validate that the status check is not currently required, which requires me merging something that fails it.
