### PR TITLE
chore: update actionlint version

### DIFF
--- a/.github/actions/lint-all/action.yml
+++ b/.github/actions/lint-all/action.yml
@@ -45,7 +45,7 @@ inputs:
   # Note, must not start with GITHUB_
   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#naming-conventions-for-configuration-variables
   actions_lint_actionlint_version:
-    default: '1.7.7'
+    default: '1.7.12'
   ##############
   ## DOCKER ####
   ##############

--- a/.github/actions/lint-github-actions/action.yml
+++ b/.github/actions/lint-github-actions/action.yml
@@ -18,7 +18,7 @@ inputs:
   actionlint_version:
     description: 'The version of actionlint to install and use.'
     type: 'string'
-    default: '1.7.7'
+    default: '1.7.12'
   shellcheck_version:
     description: 'The version of actionlint to install and use.'
     type: 'string'


### PR DESCRIPTION
Update actionlint version to 1.7.12(ref: https://github.com/rhysd/actionlint/blob/main/CHANGELOG.md). 

This would solve the problem when updating `node24` for GitHub Actions Runners(e.g. https://github.com/abcxyz/github-token-minter/actions/runs/25341232344?pr=253), as nodejs 24 won't be supported until actionlint 1.7.8.