### PR TITLE
chore(multi-approvers): upgrade runtime to Node 24

### DIFF
--- a/.github/actions/multi-approvers/action.yml
+++ b/.github/actions/multi-approvers/action.yml
@@ -16,5 +16,5 @@ inputs:
     type: 'string'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Upgrade the execution runtime for the `multi-approvers` action from Node 20 to Node 24 to address the deprecation of Node 20 in GitHub Actions.

Tested by compiling and running the test suite under Node 24, with all tests passing.

Fixes #151