### PR TITLE
feat: onboard to Renovate and add Ratchet comment enforcement with self-testing CI

### DIFF
--- a/.github/actions/lint-github-actions/action.yml
+++ b/.github/actions/lint-github-actions/action.yml
@@ -53,3 +53,11 @@ runs:
           -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Filepath}}@{{$err.Line}} {{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' \
           -ignore 'SC2016:' \
           -ignore 'label ".+" is unknown'
+
+    - name: 'Check Ratchet Pin Comments'
+      shell: 'bash'
+      run: '${{ github.action_path }}/check_ratchet.sh'
+
+    - name: 'Run check_ratchet Unit Tests'
+      shell: 'bash'
+      run: '${{ github.action_path }}/check_ratchet_test.sh'

--- a/.github/actions/lint-github-actions/check_ratchet.sh
+++ b/.github/actions/lint-github-actions/check_ratchet.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check_ratchet.sh
+#
+# This script verifies that all GitHub Actions 'uses' statements in the repository's
+# workflows and composite actions are securely pinned to a commit SHA and annotated
+# with a matching '# ratchet:' comment showing the original version tag (or explicitly
+# excluded via '# ratchet:exclude').
+#
+# This ensures that external dependencies are immutable (for security) and maintainable
+# by automated tools like Renovate.
+
+set -euo pipefail
+
+# Static regex patterns (Read-only globals)
+# Group 1 is optional leading hyphen, Group 2 is the action reference
+readonly PATTERN_USES="^(-[[:space:]]*)?uses:[[:space:]]*['\"]?([^'\"]+)['\"]?"
+readonly PATTERN_VARIABLE="\$\{\{"
+readonly PATTERN_LOCAL="^\./"
+readonly PATTERN_EXCLUDE="#[[:space:]]*ratchet:exclude"
+readonly PATTERN_SHA="@([[:alnum:]]{40})$"
+
+# Lints a single workflow or action file for correct Ratchet annotations.
+# Arguments:
+#   $1: Path to the YAML file to check.
+# Returns:
+#   0 if valid, 1 if errors were found.
+lint_file() {
+  local file="${1}"
+  local exit_code=0
+  local line_num=0
+  local line
+  local trimmed_line
+  local temp
+  local action
+  local action_name
+  local pattern_ratchet
+
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line_num=$((line_num + 1))
+    
+    # Trim leading and trailing whitespace using pure Bash (no subprocess)
+    temp="${line#"${line%%[![:space:]]*}"}"
+    trimmed_line="${temp%"${temp##*[![:space:]]}"}"
+    
+    # Check for "uses:"
+    if [[ "${trimmed_line}" =~ ${PATTERN_USES} ]]; then
+      action="${BASH_REMATCH[2]}"
+      
+      # Skip dynamic uses (containing variables)
+      if [[ "${action}" =~ ${PATTERN_VARIABLE} ]]; then
+        continue
+      fi
+      
+      # Check if local action
+      if [[ "${action}" =~ ${PATTERN_LOCAL} ]]; then
+        # Local actions are inherently safe, no pinning required
+        continue
+      fi
+      
+      # External action
+      if [[ "${action}" =~ ${PATTERN_SHA} ]]; then
+        # Extract action name using pure Bash (no subprocess)
+        action_name="${action%@*}"
+        
+        if [[ "${trimmed_line}" =~ ${PATTERN_EXCLUDE} ]]; then
+          continue
+        fi
+        
+        # Expected: # ratchet:<action_name>@<version>
+        pattern_ratchet="#[[:space:]]*ratchet:${action_name}@([^[:space:]]+)"
+        
+        if [[ ! "${trimmed_line}" =~ ${pattern_ratchet} ]]; then
+          echo "::error file=${file},line=${line_num}::Pinned action '${action}' is missing a valid '# ratchet:${action_name}@<version>' comment"
+          exit_code=1
+        fi
+      else
+        # Unpinned action
+        if [[ ! "${trimmed_line}" =~ ${PATTERN_EXCLUDE} ]]; then
+          echo "::error file=${file},line=${line_num}::Action '${action}' is not pinned to a SHA and is not excluded via '# ratchet:exclude'"
+          exit_code=1
+        fi
+      fi
+    fi
+  done < "${file}"
+
+  return "${exit_code}"
+}
+
+main() {
+  local global_exit_code=0
+  local file
+  local find_pid
+  local search_dirs=(".github/workflows" ".github/actions")
+
+  # Allow overriding search targets for unit testing
+  if [[ $# -gt 0 ]]; then
+    search_dirs=("$@")
+  fi
+
+  # Open find process substitution on file descriptor 3 to safely capture its PID
+  # and avoid silent pass bugs if find fails (SC2312).
+  # shellcheck disable=SC2312
+  exec 3< <(find "${search_dirs[@]}" \
+    -not -path "*/node_modules/*" \
+    -type f \( -name "*.yml" -o -name "*.yaml" \) \
+    -print0)
+  find_pid=$!
+
+  while IFS= read -r -d '' file <&3; do
+    # It is safe to disable set -e inside lint_file because it handles its own exit codes.
+    # shellcheck disable=SC2310
+    if ! lint_file "${file}"; then
+      global_exit_code=1
+    fi
+  done
+
+  # Close file descriptor 3
+  exec 3<&-
+
+  # Wait for find process to ensure it completed successfully (prevents silent passes)
+  wait "${find_pid}"
+
+  if [[ "${global_exit_code}" -eq 0 ]]; then
+    echo "All ratchet comments are valid."
+  fi
+
+  return "${global_exit_code}"
+}
+
+main "$@"

--- a/.github/actions/lint-github-actions/check_ratchet_test.sh
+++ b/.github/actions/lint-github-actions/check_ratchet_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check_ratchet_test.sh
+#
+# Unit tests for the check_ratchet.sh linter script.
+# It creates various valid and invalid mock workflows and asserts that the linter
+# behaves correctly (passes on valid inputs, fails and reports errors on invalid inputs).
+
+set -euo pipefail
+
+# Locate the script under test portably (works on macOS and Linux)
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+readonly SCRIPT_DIR
+readonly SCRIPT_UNDER_TEST="${SCRIPT_DIR}/check_ratchet.sh"
+
+# Temporary directory for mock files
+TEST_TEMP_DIR=$(mktemp -d)
+readonly TEST_TEMP_DIR
+
+# Clean up temporary directory on exit
+cleanup() {
+  rm -rf "${TEST_TEMP_DIR}"
+}
+trap cleanup EXIT
+
+# Test Case 1: Valid inputs should pass (Exit code 0)
+test_valid_inputs() {
+  echo "Running test: test_valid_inputs..."
+  
+  # Create a temporary subdir for this test to isolate it
+  local case_dir="${TEST_TEMP_DIR}/valid"
+  mkdir -p "${case_dir}"
+  
+  echo "
+name: 'valid-workflow'
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+      - uses: './.github/actions/lint-java'
+      - uses: 'actions/checkout@v4' # ratchet:exclude
+" > "${case_dir}/valid.yml"
+
+  # Run linter on this subdir
+  local output
+  if ! output=$("${SCRIPT_UNDER_TEST}" "${case_dir}" 2>&1); then
+    echo "❌ FAILED: Valid inputs caused a failure!"
+    echo "Output:"
+    echo "${output}"
+    return 1
+  fi
+
+  if [[ "${output}" != *"All ratchet comments are valid."* ]]; then
+    echo "❌ FAILED: Missing success message!"
+    echo "Output:"
+    echo "${output}"
+    return 1
+  fi
+
+  echo "✅ PASSED"
+  return 0
+}
+
+# Test Case 2: Invalid inputs should fail (Exit code 1) and report specific errors
+test_invalid_inputs() {
+  echo "Running test: test_invalid_inputs..."
+  
+  local case_dir="${TEST_TEMP_DIR}/invalid"
+  mkdir -p "${case_dir}"
+  
+  # 1. Pinned but missing comment (Line 7)
+  # 2. Unpinned and no exclude (Line 9)
+  # 3. Mismatched comment action (Line 11)
+  echo "
+name: 'invalid-workflow'
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683'
+      
+      - uses: 'actions/checkout@v4'
+      
+      - uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/setup-node@v4
+" > "${case_dir}/invalid.yml"
+
+  local output
+  local exit_code=0
+  output=$("${SCRIPT_UNDER_TEST}" "${case_dir}" 2>&1) || exit_code=$?
+
+  if [[ "${exit_code}" -ne 1 ]]; then
+    echo "❌ FAILED: Expected exit code 1, got ${exit_code}"
+    echo "Output:"
+    echo "${output}"
+    return 1
+  fi
+
+  # Verify specific error messages are printed with correct line numbers
+  local err1="Pinned action 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' is missing a valid '# ratchet:actions/checkout@<version>' comment"
+  local err2="Action 'actions/checkout@v4' is not pinned to a SHA and is not excluded via '# ratchet:exclude'"
+
+  if [[ "${output}" != *"invalid.yml,line=7::${err1}"* ]]; then
+    echo "❌ FAILED: Missing or incorrect error for Case 1 (line 7)!"
+    echo "Output:"
+    echo "${output}"
+    return 1
+  fi
+
+  if [[ "${output}" != *"invalid.yml,line=9::${err2}"* ]]; then
+    echo "❌ FAILED: Missing or incorrect error for Case 2 (line 9)!"
+    echo "Output:"
+    echo "${output}"
+    return 1
+  fi
+
+  if [[ "${output}" != *"invalid.yml,line=11::${err1}"* ]]; then
+    echo "❌ FAILED: Missing or incorrect error for Case 3 (line 11)!"
+    echo "Output:"
+    echo "${output}"
+    return 1
+  fi
+
+  echo "✅ PASSED"
+  return 0
+}
+
+# Run all tests
+main() {
+  test_valid_inputs
+  test_invalid_inputs
+  echo "All unit tests passed successfully!"
+}
+
+main "$@"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm non-major dependencies",
+      "groupSlug": "npm-non-major"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions non-major dependencies",
+      "groupSlug": "github-actions-non-major"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
This PR onboards the `abcxyz/actions` repository to Renovate bot for automated dependency management, and introduces a robust, self-tested presubmit check to ensure all GitHub Actions remain secure and maintainable.

This fully addresses and resolves #152.

---

### Rationale & Design Choices

#### 1. Renovate Configuration (`renovate.json`)
We have added a production-ready `renovate.json` in the root. To prevent PR noise while keeping the repository secure:
*   **Grouped Non-Major Updates:** Minor and patch updates for `npm` and `github-actions` are grouped into separate, single PRs (`npm-non-major` and `github-actions-non-major`).
*   **Major Updates:** Kept as individual PRs to ensure they receive dedicated manual review and testing.
*   **Ratchet Compatibility:** Renovate natively detects and updates `ratchet` style comments (e.g. `# ratchet:actions/checkout@v4`) to bump both the SHA and the comment version.

#### 2. Presubmit Safety Check (`check_ratchet.sh`)
While Renovate natively maintains `ratchet` comments, it requires those comments to exist in the first place. Standard `ratchet lint` only ensures that actions are pinned to a SHA, but **does not** enforce that the `# ratchet:` version annotation exists. 

To prevent developers from adding pinned actions without version context (which would make them unmaintainable by Renovate), we introduced a custom safety linter:
*   **`check_ratchet.sh`:** A robust, Google-style Bash script that scans all workflow and composite action YAML files (supporting list item hyphens and various quote types).
*   **Enforcement:** It verifies that every external action is either pinned to a SHA **and** has a matching `# ratchet:action@version` comment, or is explicitly excluded via `# ratchet:exclude`.

#### 3. Self-Testing Linter CI (`check_ratchet_test.sh`)
To ensure the new safety linter itself is robust and never suffers from regressions (e.g., "silent passes"), we have implemented a comprehensive unit test suite:
*   **Automated Sandbox:** The test script uses `mktemp -d` to create isolated mock workflows containing various valid and invalid configurations.
*   **Assertions:** It strictly asserts the linter's exit codes, output error messages, and correct line numbers for all edge cases (pinned-missing-comments, unpinned-no-excludes, mismatched-comment-action-names).
*   **CI Integration:** Both the repository linter step and the unit test step have been integrated into the `lint-github-actions` composite action. CI will now automatically verify the health of the linter on every run.

---

### Detailed Changes

*   `A renovate.json`: Renovate bot configuration file.
*   `M .github/actions/lint-github-actions/action.yml`: Integrated both the `check_ratchet.sh` execution and the `check_ratchet_test.sh` unit test execution steps.
*   `A .github/actions/lint-github-actions/check_ratchet.sh`: Custom linter script enforcing Ratchet comment presence and correctness (supporting target arguments for testability).
*   `A .github/actions/lint-github-actions/check_ratchet_test.sh`: Dedicated, automated unit test suite for the linter.

---

### Testing
*   **Automated Unit Tests:** The new `check_ratchet_test.sh` suite was executed locally and passed successfully:
    ```text
    Running test: test_valid_inputs...
    ✅ PASSED
    Running test: test_invalid_inputs...
    ✅ PASSED
    All unit tests passed successfully!
    ```

---

### Closes
Closes #152