### PR TITLE
feat: add dependabot configuration for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
This PR introduces a `.github/dependabot.yml` configuration to automate version updates for the `github-actions` ecosystem (workflows and actions). 

Once merged, Dependabot will run weekly and automatically open Pull Requests to keep all of the GitHub Actions used in this repository up to date.

### Notes on the `npm` ecosystem

We initially attempted to configure Dependabot to also handle the `npm` dependencies for `/.github/actions/multi-approvers`. However, we discovered a strict GitHub API limitation:
* GitHub's security policies prevent standard Dependabot tokens from creating Pull Requests that modify files inside the `.github/` directory.
* While the `github-actions` ecosystem gets a special `workflows` permission token to bypass this, the `npm` ecosystem does not.
* Therefore, automated Dependabot PRs for the `multi-approvers` action will always be rejected by the API with a 400 Bad Request (`The request contains invalid or unauthorized changes`).

Because of this limitation, the `npm` configuration was intentionally omitted from this PR. Updates to `/.github/actions/multi-approvers` will need to continue being performed manually.

### Related Issues
Resolves #157